### PR TITLE
feat(spl-to-apl): restructure skill, make it more concise

### DIFF
--- a/skills/spl-to-apl/SKILL.md
+++ b/skills/spl-to-apl/SKILL.md
@@ -5,7 +5,7 @@ description: Translates Splunk SPL queries to Axiom APL. Provides command mappin
 
 # SPL to APL Translator
 
-Expert translator from Splunk Processing Language (SPL) to Axiom Processing Language (APL).
+Expert translator from Splunk Processing Language (SPL) to Axiom Processing Language (APL). 
 
 ## Critical Differences
 


### PR DESCRIPTION
- more concise, focused on critical differences upfront
- better structured for quick reference

---

updates based on [research I did in another project](https://gist.github.com/bdsqqq/a699a7d85d43f5df0c6e0fe93c827e65)

TLDR: 
original skill hits all the things right,
but is very heavy on tokens,
agents are likely miss references in the middle of long prompts/reference docs

so wanted to compress a bit of the skill.md,
and maybe break up the reference files into smaller files by categories that the model can reference more directly based on what they need

(i know a year is pretty much a decate in AI, but sources are:
> Our findings revealed that LLMs exhibit significant sensitivity to both the language and position of the relevant information, particularly when the relevant content is in non-Latin languages or positioned in the middle of a long context
> - in conclusion of https://arxiv.org/html/2408.10151v1#S6

and

> models are often muchbetter at using relevant information that occurs atthe very beginning (primacy bias) and very end ofcontexts (recency bias), and suffer degraded perfor-mance when forced to use information within themiddle of its input context.
> - fig 5 in https://export.arxiv.org/pdf/2307.03172v3