### PR TITLE
fix: use correct vercel ai gateway model id for opus 4.5

### DIFF
--- a/eval-tooling/src/harnesses/prompt-injection.ts
+++ b/eval-tooling/src/harnesses/prompt-injection.ts
@@ -24,7 +24,7 @@ import matter from "gray-matter";
 import type { HarnessResult } from "./types";
 import { buildSkillMetadata, parseModelId } from "../shared/metadata";
 
-const MODEL_ID = "anthropic/claude-opus-4-5-20250514";
+const MODEL_ID = "anthropic/claude-opus-4.5";
 const model = wrapAISDKModel(gateway(MODEL_ID));
 
 export interface PromptInjectionOptions {

--- a/eval-tooling/src/harnesses/tool-simulation.ts
+++ b/eval-tooling/src/harnesses/tool-simulation.ts
@@ -30,7 +30,7 @@ import matter from "gray-matter";
 import type { HarnessResult } from "./types";
 import { buildSkillMetadata, parseModelId } from "../shared/metadata";
 
-const MODEL_ID = "anthropic/claude-opus-4-5-20250514";
+const MODEL_ID = "anthropic/claude-opus-4.5";
 const model = wrapAISDKModel(gateway(MODEL_ID));
 
 export interface ToolSimulationOptions {


### PR DESCRIPTION
Model ID should be `anthropic/claude-opus-4.5` not `anthropic/claude-opus-4-5-20250514`