### PR TITLE
fix(eval): extract correct baselineId format

### DIFF
--- a/.eval-baselines.json
+++ b/.eval-baselines.json
@@ -2,7 +2,7 @@
   "$schema": "./.github/eval-baselines.schema.json",
   "baselines": {
     "spl-to-apl": {
-      "baselineId": "spl-translation-7F8XA4DX91",
+      "baselineId": "b7286d3c7ad87f0b60d67b5aca6b6ba0",
       "commit": "163241fd53410283ac3d87ed51d11b42c30792aa",
       "updatedAt": "2026-01-22T16:59:16Z"
     }

--- a/.github/eval-baselines.schema.json
+++ b/.github/eval-baselines.schema.json
@@ -15,7 +15,7 @@
         "properties": {
           "baselineId": {
             "type": "string",
-            "description": "Axiom baseline ID in format <eval-name>-<runId>"
+            "description": "Axiom baseline ID (hex hash from baselineId query param)"
           },
           "commit": {
             "type": "string",

--- a/.github/workflows/update-eval-baselines.yml
+++ b/.github/workflows/update-eval-baselines.yml
@@ -128,15 +128,9 @@ jobs:
           sed 's/\x1b\[[0-9;]*m//g' eval-output-raw.txt > eval-output.txt
           
           # Extract baseline ID from output
-          # URL format: https://app.axiom.co/.../evaluations/<eval-name>/<runId>?...
-          # The --baseline flag needs format: <eval-name>-<runId>
-          url_match=$(grep -oE '/evaluations/[^/]+/[A-Z0-9]+' eval-output.txt | head -1 || true)
-          if [ -n "$url_match" ]; then
-            # Extract eval-name and runId, combine as eval-name-runId
-            eval_name=$(echo "$url_match" | cut -d'/' -f3)
-            run_id=$(echo "$url_match" | cut -d'/' -f4)
-            baseline_id="${eval_name}-${run_id}"
-          fi
+          # URL format: https://app.axiom.co/.../evaluations/<eval-name>/<runId>?baselineId=<id>
+          # The --baseline flag needs the baselineId query param value
+          baseline_id=$(grep -oE 'baselineId=[a-f0-9]+' eval-output.txt | head -1 | cut -d= -f2 || true)
           
           if [ -n "$baseline_id" ]; then
             echo "baseline_id=$baseline_id" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The eval baseline comparison shows "Baseline: (none)" even though the baseline ID is being passed correctly.

## Root cause

The workflow was extracting the wrong ID format from the axiom eval output URL:
- **Extracted**: `spl-translation-7F8XA4DX91` (from URL path)
- **Expected**: `b7286d3c7ad87f0b60d67b5aca6b6ba0` (from `baselineId` query param)

The CLI output shows:
```
https://app.axiom.co/.../evaluations/spl-translation/7F8XA4DX91?baselineId=b7286d3c7ad87f0b60d67b5aca6b6ba0
```

The `--baseline` flag expects the hex hash from the `baselineId` query parameter.

## Fix

Update the extraction regex to capture `baselineId=<hash>` from the URL.

## After merge

1. Manually trigger "Update Eval Baselines" workflow for spl-to-apl to regenerate with correct ID format
2. Subsequent PR evals will use the correct baseline for comparison