### PR TITLE
feat(eval): add model id to eval metadata

### DIFF
--- a/eval-tooling/src/harnesses/index.ts
+++ b/eval-tooling/src/harnesses/index.ts
@@ -9,6 +9,8 @@ import { runPromptInjection, type PromptInjectionOptions } from "./prompt-inject
 import { runToolSimulation, type ToolSimulationOptions } from "./tool-simulation";
 import type { HarnessResult } from "./types";
 
+export const MODEL_ID = "anthropic/claude-opus-4.5";
+
 export type HarnessType = "prompt-injection" | "tool-simulation";
 
 export interface HarnessTypeMetadata {

--- a/skills/spl-to-apl/.meta/spl-to-apl.eval.ts
+++ b/skills/spl-to-apl/.meta/spl-to-apl.eval.ts
@@ -1,7 +1,7 @@
 import { Eval, Scorer } from "axiom/ai/evals";
 import { testCases } from "./cases";
 import { flag, pickFlags, getGitCommit, buildSkillMetadata } from "../../../eval-tooling/src/shared";
-import { runHarness, type HarnessType, type HarnessResult } from "../../../eval-tooling/src/harnesses";
+import { runHarness, MODEL_ID, type HarnessType, type HarnessResult } from "../../../eval-tooling/src/harnesses";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
@@ -131,6 +131,7 @@ Eval("spl-translation", {
   configFlags: pickFlags("harnessType", "harnessVersion", "git"),
   metadata: {
     description: "Evaluates SPL to APL translation quality",
+    model: MODEL_ID,
     testCaseCount: testCases.length,
     git: {
       commit: gitCommit,


### PR DESCRIPTION
adds model id to eval metadata for easier filtering in axiom ui.

- exports MODEL_ID from harnesses index
- includes in spl-to-apl eval metadata

model: `anthropic/claude-opus-4.5`