### PR TITLE
fix(building-dashboards): require metricsDataset on MPL charts

### DIFF
--- a/skills/building-dashboards/reference/metrics-mpl.md
+++ b/skills/building-dashboards/reference/metrics-mpl.md
@@ -2,7 +2,11 @@
 
 This reference documents the chart query contract for *metrics-backed* dashboard charts.
 
-Metrics charts place the MPL pipeline string in the `query.apl` field (the same field used for APL queries). Do not send `query.metricsDataset` or `query.mpl` in create payloads — the create API rejects both even though GET responses for existing dashboards may include them.
+Metrics charts place the MPL pipeline string in the `query.apl` field (the same field used for APL queries) and **must** also include `query.metricsDataset` — this is what tags the chart as a metrics chart so the renderer routes it to the MPL parser instead of the APL parser. Do not send `query.mpl` — the API rejects it.
+
+> **Critical:** if you omit `query.metricsDataset`, the API accepts the payload (it falls through to the non-metrics APL variant of the schema) but the chart renders as `Error: line: 1, col: 1: invalid input text` because the frontend sends the MPL string to the APL parser. `metricsDataset` is the only signal that distinguishes a metrics chart from an APL chart — it is not optional.
+>
+> **When updating an existing dashboard:** the legacy UI-written shape uses a `query.mpl` field. Rename `mpl` → `apl` to pass validation, but **keep** `metricsDataset`, `metricsMetric`, `metricsFilter`, and `metricsTransformations`. Do not strip them.
 
 > **CRITICAL:** Run `scripts/metrics/metrics-spec <deployment> <dataset>` before composing your first MPL query in a session. NEVER guess MPL syntax.
 
@@ -11,8 +15,11 @@ Metrics charts place the MPL pipeline string in the `query.apl` field (the same 
 ```json
 {
   "type": "TimeSeries",
+  "datasetId": "otel-metrics",
   "query": {
-    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| align to 1m using avg\n| group by `service.name` using avg"
+    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| align to 1m using avg\n| group by `service.name` using avg",
+    "metricsDataset": "otel-metrics",
+    "metricsMetric": "http.server.duration"
   }
 }
 ```
@@ -22,13 +29,13 @@ Metrics charts place the MPL pipeline string in the `query.apl` field (the same 
 | Field | Required? | Description |
 |-------|-----------|-------------|
 | `apl` | ✅ Yes | The MPL pipeline string. Use this field even for MPL content. |
-| `metricsDataset` | ❌ No | Readback/UI field. Do not send in create payloads; the create API rejects it. |
-| `mpl` | ❌ No | Readback field. GET may return it, but create expects the same string in `apl`. |
-| `metricsMetric` | ❌ No | UI/editor metadata; not needed for hand-authored create payloads |
-| `metricsFilter` | ❌ No | UI/editor metadata; not needed for hand-authored create payloads |
-| `metricsTransformations` | ❌ No | UI/editor metadata; not needed for hand-authored create payloads |
+| `metricsDataset` | ✅ Yes | Tags the chart as a metrics chart. Without this, the renderer sends the string to the APL parser and the chart fails with `invalid input text`. |
+| `metricsMetric` | ☑️ Recommended | The metric name (same identifier that appears after the `:` in the MPL source). Optional in the schema but the UI always writes it. |
+| `metricsFilter` | ☑️ Recommended | Structured filter tree — defaults to `{op: "and", children: []}` when absent. Preserve if present on an existing chart. |
+| `metricsTransformations` | ☑️ Recommended | Align/group/bucket transformations. Preserve if present on an existing chart. |
+| `mpl` | ❌ No | Rejected by the API. If an existing dashboard has this field, rename it to `apl` and preserve `metricsDataset`. |
 
-> **Why `apl`?** The dashboard create API uses `apl` as the query text field for both APL and MPL queries. The dataset/metric selector is embedded in the MPL string itself (for example, `` `otel-metrics`:`http.server.duration` ``).
+> **Why `apl`?** The v2 dashboard API uses `apl` as the query text field for both APL and MPL queries. The dataset/metric selector is embedded in the MPL string itself (for example, `` `otel-metrics`:`http.server.duration` ``). The `metricsDataset` sibling field is what distinguishes an MPL chart from an APL chart at render time.
 
 ## Authoring Checklist
 
@@ -37,7 +44,7 @@ When generating metrics chart JSON:
 1. Confirm dataset kind is `otel:metrics:v1` via `scripts/metrics/datasets <deploy>`.
 2. Run `scripts/metrics/metrics-spec` to learn the full MPL syntax — **mandatory, never guess**.
 3. Discover available metrics and tags with `scripts/metrics/metrics-info`. If results are empty, retry with `--start` set to 7 days ago (sparse metrics may not have data in the default 24h window).
-4. Put the full MPL pipeline in `query.apl` only. Do not set `query.metricsDataset` or `query.mpl` in create payloads.
+4. Put the full MPL pipeline in `query.apl`, and always set `query.metricsDataset` (required) and `query.metricsMetric` (recommended). Do not set `query.mpl` — the API rejects it. When **updating** an existing chart that already has `metricsFilter` or `metricsTransformations`, preserve them.
 5. Validate your query with `scripts/metrics/metrics-query` before embedding in the dashboard.
 
 > **Note:** `find-metrics <value>` searches tag values, not metric names. Use `metrics-info <deploy> <dataset> metrics` to list metric names.


### PR DESCRIPTION
The previous guidance told agents to drop `query.metricsDataset` when writing metrics charts, claiming the API rejects it. That's incorrect: the v2 dashboards API accepts `metricsDataset`, and the frontend *requires* it to route the chart to the MPL parser instead of the APL parser.

Without `metricsDataset`, the API accepts the payload (it falls through to the non-metrics APL variant of the union schema), but the chart renders as `Error: line: 1, col: 1: invalid input text` because the frontend sends the MPL string to the APL parser.

This was damaging dashboards on UPDATE specifically: when the agent hit the Zod rejection on the legacy `query.mpl` field, it followed this doc and stripped `metricsDataset` along with `mpl`, producing a shape that passes validation but cannot render. Fresh CREATE flows were unaffected because the MCP already writes `metricsDataset` in new payloads.

Changes:
- Mark `metricsDataset` as required (✅ Yes) with an explicit note that omitting it causes the renderer to misclassify the chart.
- Mark `metricsMetric`, `metricsFilter`, `metricsTransformations` as recommended, with a "preserve if present on update" instruction.
- Canonical JSON example now includes `metricsDataset` and `metricsMetric`.
- Authoring checklist step 4 updated with the correct fields to send and a reminder to preserve existing metrics fields on update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is behavioral guidance shifts that could affect how agents craft dashboard payloads.
> 
> **Overview**
> Updates the Metrics/MPL dashboard chart contract to **require** `query.metricsDataset` (and recommend preserving `metricsMetric`, `metricsFilter`, and `metricsTransformations`) so MPL charts are correctly routed to the MPL parser at render time.
> 
> Refreshes the canonical JSON example and authoring checklist to include `metricsDataset`/`metricsMetric`, explicitly warns that omitting `metricsDataset` can pass API validation but fail rendering, and clarifies update guidance to rename legacy `query.mpl` to `query.apl` without stripping existing metrics fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a7e7d1afe30cd929c15d8cfe9121fb77dd74f80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->