### PR TITLE
fix(dashboards): mpl chart queries require 'apl' and 'metricsDataset'

### DIFF
--- a/skills/building-dashboards/SKILL.md
+++ b/skills/building-dashboards/SKILL.md
@@ -170,17 +170,18 @@ Use descriptive kebab-case IDs (e.g. `error-rate`, `p95-latency`, `traffic-rps`)
 
 ## Metrics/MPL Chart Contract
 
-Metrics-backed charts place the MPL pipeline string in `query.apl` only.
+Metrics-backed charts require both `query.apl` (the MPL pipeline string) and `query.metricsDataset` (the dataset name). The `metricsDataset` field is what tells the backend to interpret `apl` as MPL rather than APL — omitting it causes the chart to misbehave even if the pipeline string is well-formed.
 
 > **CRITICAL:** Run `scripts/metrics/metrics-spec <deployment> <dataset>` before composing your first MPL query in a session. NEVER guess MPL syntax.
 >
-> **API gotcha:** The create API rejects `query.metricsDataset` and `query.mpl` even though GET responses for existing metrics dashboards may include them. For create payloads, put the full MPL string in `query.apl` and omit both fields.
+> **API gotcha:** Set `query.metricsDataset` to the dataset name (e.g. `"otel-metrics"`). The create API rejects `query.mpl` even though GET responses for existing metrics dashboards may include it — put the MPL string in `query.apl` instead.
 
 ```json
 {
   "type": "TimeSeries",
   "query": {
-    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| align to 1m using avg\n| group by `service.name` using avg"
+    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| align to 1m using avg\n| group by `service.name` using avg",
+    "metricsDataset": "otel-metrics"
   }
 }
 ```
@@ -548,7 +549,7 @@ org_id = "your-org-id"
 3. Design dashboard using the Metrics/MPL Blueprint
 4. Write MPL for each panel
 5. **Validate queries** with `scripts/metrics/metrics-query` using explicit time range
-6. Build JSON (put the full MPL string in `query.apl` only — do not set `query.metricsDataset` or `query.mpl`)
+6. Build JSON: put the full MPL string in `query.apl` AND set `query.metricsDataset` to the dataset name (required — denotes the chart as MPL). Do not set `query.mpl` (rejected by create API).
 7. `dashboard-validate` to check structure
 8. `dashboard-create` or `dashboard-update` to deploy
 9. **`dashboard-link` to get URL**
@@ -604,7 +605,7 @@ scripts/dashboard-create prod ./dashboard.json
 | Metrics discovery returns empty | Sparse metrics (sensors, batch, cron) outside default 24h window | Retry with `--start` set to 7 days ago; some metrics only report intermittently |
 | 404 from metrics API calls | Used `scripts/axiom-api` (dashboard) instead of `scripts/metrics/axiom-api` (data) | Use `scripts/metrics/axiom-api` for all `/v1/query/`, `/v1/datasets` paths |
 | `find-metrics` returns unexpected results | It searches tag values, not metric names | Use `metrics-info <deploy> <dataset> metrics` to list metric names; `find-metrics` finds metrics associated with a known tag value |
-| `metricsDataset` rejected on create | Create API does not accept `query.metricsDataset` for metrics charts | Put the full MPL pipeline in `query.apl` only |
+| Metrics chart renders blank or wrong values | Missing `query.metricsDataset` — backend treats `apl` as APL, not MPL | Set `query.metricsDataset` to the dataset name alongside `query.apl` |
 | `query.mpl` rejected on create | GET may return `query.mpl` for existing metrics charts, but create expects `query.apl` | Move/copy the MPL string into `query.apl` before deploy |
 | `decimals` rejected on create | Create API does not accept chart-level `decimals` even though GET may return it | Omit `decimals` from create payloads |
 

--- a/skills/building-dashboards/reference/chart-config.md
+++ b/skills/building-dashboards/reference/chart-config.md
@@ -14,7 +14,7 @@ Charts support JSON configuration options beyond the query. These are set at the
 
 ## Metrics/MPL Query (MetricsDB Charts)
 
-Metrics charts put the full MPL pipeline string in `query.apl` only. Do not send `query.metricsDataset` or `query.mpl` in create payloads — the create API rejects both even though GET responses for existing dashboards may include them. Run `scripts/metrics/metrics-spec` to learn the full syntax before composing queries.
+Metrics charts require both `query.apl` (the MPL pipeline string) and `query.metricsDataset` (the dataset name, e.g. `"otel-metrics"`). The `metricsDataset` field is what flags the chart as MPL; without it the backend treats `apl` as APL and the chart misbehaves. Do not send `query.mpl` — the create API rejects it. Run `scripts/metrics/metrics-spec` to learn the full syntax before composing queries.
 
 ### Minimal Metrics Query
 
@@ -22,7 +22,8 @@ Metrics charts put the full MPL pipeline string in `query.apl` only. Do not send
 {
   "type": "TimeSeries",
   "query": {
-    "apl": "`otel-metrics`:`system.cpu.utilization`"
+    "apl": "`otel-metrics`:`system.cpu.utilization`",
+    "metricsDataset": "otel-metrics"
   }
 }
 ```
@@ -33,7 +34,8 @@ Metrics charts put the full MPL pipeline string in `query.apl` only. Do not send
 {
   "type": "TimeSeries",
   "query": {
-    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| where `deployment.environment` == \"prod\"\n| align to 1m using avg\n| group by `service.name` using avg"
+    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| where `deployment.environment` == \"prod\"\n| align to 1m using avg\n| group by `service.name` using avg",
+    "metricsDataset": "otel-metrics"
   }
 }
 ```

--- a/skills/building-dashboards/reference/metrics-mpl.md
+++ b/skills/building-dashboards/reference/metrics-mpl.md
@@ -2,7 +2,12 @@
 
 This reference documents the chart query contract for *metrics-backed* dashboard charts.
 
-Metrics charts place the MPL pipeline string in the `query.apl` field (the same field used for APL queries). Do not send `query.metricsDataset` or `query.mpl` in create payloads — the create API rejects both even though GET responses for existing dashboards may include them.
+Metrics charts require **two** fields:
+
+- `query.apl` — the MPL pipeline string (same field name used for APL queries).
+- `query.metricsDataset` — the dataset name (e.g. `"otel-metrics"`). This field is what tells the backend to interpret `apl` as MPL. Without it, the chart will not behave correctly even if the pipeline string is well-formed.
+
+Do not send `query.mpl` in create payloads — the create API rejects it even though GET responses for existing metrics dashboards may include it.
 
 > **CRITICAL:** Run `scripts/metrics/metrics-spec <deployment> <dataset>` before composing your first MPL query in a session. NEVER guess MPL syntax.
 
@@ -12,7 +17,8 @@ Metrics charts place the MPL pipeline string in the `query.apl` field (the same 
 {
   "type": "TimeSeries",
   "query": {
-    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| align to 1m using avg\n| group by `service.name` using avg"
+    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| align to 1m using avg\n| group by `service.name` using avg",
+    "metricsDataset": "otel-metrics"
   }
 }
 ```
@@ -22,13 +28,13 @@ Metrics charts place the MPL pipeline string in the `query.apl` field (the same 
 | Field | Required? | Description |
 |-------|-----------|-------------|
 | `apl` | ✅ Yes | The MPL pipeline string. Use this field even for MPL content. |
-| `metricsDataset` | ❌ No | Readback/UI field. Do not send in create payloads; the create API rejects it. |
-| `mpl` | ❌ No | Readback field. GET may return it, but create expects the same string in `apl`. |
+| `metricsDataset` | ✅ Yes (for metrics charts) | Dataset name (e.g. `"otel-metrics"`). Denotes the chart as MPL — without it the backend treats `apl` as APL. |
+| `mpl` | ❌ No (rejected) | GET may return it for existing metrics charts, but create rejects it. Put the MPL string in `apl` instead. |
 | `metricsMetric` | ❌ No | UI/editor metadata; not needed for hand-authored create payloads |
 | `metricsFilter` | ❌ No | UI/editor metadata; not needed for hand-authored create payloads |
 | `metricsTransformations` | ❌ No | UI/editor metadata; not needed for hand-authored create payloads |
 
-> **Why `apl`?** The dashboard create API uses `apl` as the query text field for both APL and MPL queries. The dataset/metric selector is embedded in the MPL string itself (for example, `` `otel-metrics`:`http.server.duration` ``).
+> **Why both `apl` and `metricsDataset`?** The dashboard create API uses `apl` as the query text field for both APL and MPL queries. `metricsDataset` is the discriminator that flags the chart as MPL. The dataset/metric selector is also embedded in the MPL string itself (e.g. `` `otel-metrics`:`http.server.duration` ``), but `metricsDataset` must still be set explicitly.
 
 ## Authoring Checklist
 
@@ -37,7 +43,7 @@ When generating metrics chart JSON:
 1. Confirm dataset kind is `otel:metrics:v1` via `scripts/metrics/datasets <deploy>`.
 2. Run `scripts/metrics/metrics-spec` to learn the full MPL syntax — **mandatory, never guess**.
 3. Discover available metrics and tags with `scripts/metrics/metrics-info`. If results are empty, retry with `--start` set to 7 days ago (sparse metrics may not have data in the default 24h window).
-4. Put the full MPL pipeline in `query.apl` only. Do not set `query.metricsDataset` or `query.mpl` in create payloads.
+4. Put the full MPL pipeline in `query.apl` AND set `query.metricsDataset` to the dataset name. Do not set `query.mpl` — the create API rejects it.
 5. Validate your query with `scripts/metrics/metrics-query` before embedding in the dashboard.
 
 > **Note:** `find-metrics <value>` searches tag values, not metric names. Use `metrics-info <deploy> <dataset> metrics` to list metric names.

--- a/skills/building-dashboards/tests/manual-tests.md
+++ b/skills/building-dashboards/tests/manual-tests.md
@@ -200,7 +200,7 @@ Test each chart type APL pattern against `sample-http-logs` in Axiom Playground.
 
 ### 5.7 Metrics MPL Query Shape
 
-Verify metrics charts use `query.apl` only (no `metricsDataset` or `mpl`) with correct MPL pipeline syntax.
+Verify metrics charts set BOTH `query.apl` (MPL pipeline) and `query.metricsDataset` (dataset name), and do NOT set `query.mpl` (rejected by create API).
 
 **Prompt:**
 "Create a metrics TimeSeries chart for `otel-metrics:http.server.duration` filtered to `service.name=api` and `deployment.environment=prod`, with `align to 1m using avg`."
@@ -209,13 +209,16 @@ Verify metrics charts use `query.apl` only (no `metricsDataset` or `mpl`) with c
 ```json
 {
   "query": {
-    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| where `deployment.environment` == \"prod\"\n| align to 1m using avg"
+    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| where `deployment.environment` == \"prod\"\n| align to 1m using avg",
+    "metricsDataset": "otel-metrics"
   }
 }
 ```
 
 **Validation:**
-- [ ] Agent uses `query.apl` only (not `query.mpl` or `query.metricsDataset`)
+- [ ] Agent sets `query.apl` to the MPL pipeline string (NOT `query.mpl`. "mpl" is incorrect).
+- [ ] Agent sets `query.metricsDataset` to the dataset name
+- [ ] Agent does NOT set `query.mpl` (rejected on create)
 - [ ] Agent runs `scripts/metrics/metrics-spec` before composing MPL queries
 - [ ] Pipeline order matches intended execution order
 - [ ] Dotted identifiers are backtick-escaped in MPL


### PR DESCRIPTION
docs were incorrect

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that updates the required JSON shape for metrics/MPL charts; low risk aside from potential confusion if any downstream examples/tools still follow the old guidance.
> 
> **Overview**
> Updates the dashboard authoring docs to reflect that **metrics/MPL charts must set both** `query.apl` (MPL pipeline) **and** `query.metricsDataset` (dataset name) so the backend treats the query as MPL.
> 
> Clarifies the create-API behavior: `query.mpl` is rejected (even if GET returns it), and examples/manual tests/workflow guidance are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d721d86b2c5890ebbe3d0b5cef18bbc545bb0188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->