### PR TITLE
docs(dashboards): require $__interval for metrics chart alignment

### DIFF
--- a/skills/building-dashboards/SKILL.md
+++ b/skills/building-dashboards/SKILL.md
@@ -114,6 +114,17 @@ Raw events that answer "what exactly happened?"
 
 > **Prerequisite:** You MUST have run `scripts/metrics/metrics-spec` and `scripts/metrics/metrics-info` before designing panels. Never guess MPL syntax or metric/tag names.
 
+> **🚨 ALIGNMENT RULE — non-negotiable for dashboard panels:** Always align to the dashboard-supplied variable `$__interval`, not a fixed window. The dashboard runtime substitutes `$__interval` based on the active time range and panel width, so the same chart stays usable from a 5-minute to a 30-day view. Hard-coding `align to 1m` (or any constant) over-resolves long ranges and under-resolves short ones.
+>
+> ```mpl
+> | align to $__interval using avg   ✅ dashboard panels
+> | align to 1m using avg            ❌ fixed window — wrong granularity at most time ranges
+> ```
+>
+> **No `param` declaration needed in the chart `query.apl`** — the dashboard runtime injects `param $__interval: Duration;` automatically. (The Grafana datasource does the same via a preamble; the Axiom-native dashboard runtime behaves identically — verified against working production dashboards.)
+>
+> **Exceptions:** If you are pre-validating a query through `scripts/metrics/metrics-query` (which has no dashboard runtime), substitute a concrete duration for the test call only — do NOT commit that to the chart JSON. For genuinely sparse metrics where `$__interval` would round to an empty bucket (sensors, batch jobs, crons), a fixed wider window (e.g. `1h`) is acceptable; document why in the chart description.
+
 #### 1. At-a-Glance (Statistic panels)
 Current values for key metrics — answer "what's the state right now?"
 - Latest value of primary metrics (e.g., current temperature, power draw)
@@ -122,7 +133,7 @@ Current values for key metrics — answer "what's the state right now?"
 #### 2. Trends (TimeSeries panels)
 Metric trends over time — answer "what changed?"
 - Primary metrics over time, grouped by key dimension
-- Use `align to <interval> using avg|sum|last` for proper time bucketing
+- Use `align to $__interval using avg|sum|last` for proper time bucketing — `$__interval` is supplied by the dashboard runtime
 - Group by low-cardinality tags only (≤10 series per chart)
 
 #### 3. Breakdowns (TimeSeries or Table panels)
@@ -133,8 +144,8 @@ Per-entity detail — answer "where should I look?"
 
 #### 4. Entity State (TimeSeries or Table panels)
 Boolean/state metrics — answer "what is on/off/active?"
-- Use `align to <interval> using last` for state metrics
-- Sparse metrics may need wider align intervals (1h+) to show data
+- Use `align to $__interval using last` for state metrics
+- Sparse metrics may need wider **fixed** align intervals (1h+) to show data — this is the documented exception to the `$__interval` rule
 
 ---
 
@@ -180,7 +191,7 @@ Metrics-backed charts require both `query.apl` (the MPL pipeline string) and `qu
 {
   "type": "TimeSeries",
   "query": {
-    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| align to 1m using avg\n| group by `service.name` using avg",
+    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| align to $__interval using avg\n| group by `service.name` using avg",
     "metricsDataset": "otel-metrics"
   }
 }

--- a/skills/building-dashboards/reference/chart-config.md
+++ b/skills/building-dashboards/reference/chart-config.md
@@ -34,7 +34,7 @@ Metrics charts require both `query.apl` (the MPL pipeline string) and `query.met
 {
   "type": "TimeSeries",
   "query": {
-    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| where `deployment.environment` == \"prod\"\n| align to 1m using avg\n| group by `service.name` using avg",
+    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| where `deployment.environment` == \"prod\"\n| align to $__interval using avg\n| group by `service.name` using avg",
     "metricsDataset": "otel-metrics"
   }
 }

--- a/skills/building-dashboards/reference/metrics-mpl.md
+++ b/skills/building-dashboards/reference/metrics-mpl.md
@@ -17,7 +17,7 @@ Do not send `query.mpl` in create payloads — the create API rejects it even th
 {
   "type": "TimeSeries",
   "query": {
-    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| align to 1m using avg\n| group by `service.name` using avg",
+    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| align to $__interval using avg\n| group by `service.name` using avg",
     "metricsDataset": "otel-metrics"
   }
 }
@@ -44,7 +44,8 @@ When generating metrics chart JSON:
 2. Run `scripts/metrics/metrics-spec` to learn the full MPL syntax — **mandatory, never guess**.
 3. Discover available metrics and tags with `scripts/metrics/metrics-info`. If results are empty, retry with `--start` set to 7 days ago (sparse metrics may not have data in the default 24h window).
 4. Put the full MPL pipeline in `query.apl` AND set `query.metricsDataset` to the dataset name. Do not set `query.mpl` — the create API rejects it.
-5. Validate your query with `scripts/metrics/metrics-query` before embedding in the dashboard.
+5. **Use `align to $__interval`, not a fixed window.** The dashboard runtime injects `$__interval` based on the time picker and panel width; a fixed `align to 1m` produces broken granularity outside its design range. Do not add `param $__interval: Duration;` to the chart string — the runtime injects it. Pre-validation via `scripts/metrics/metrics-query` requires substituting a concrete duration for that call only.
+6. Validate your query with `scripts/metrics/metrics-query` before embedding in the dashboard.
 
 > **Note:** `find-metrics <value>` searches tag values, not metric names. Use `metrics-info <deploy> <dataset> metrics` to list metric names.
 


### PR DESCRIPTION
## Summary

Adds a new constraint to the `building-dashboards` skill: **metrics dashboard panels must align to the dashboard-supplied `$__interval` variable, not a fixed window.**

The dashboard runtime substitutes `$__interval` based on the active time range and panel width, so a single chart stays usable from a 5-minute to a 30-day view. Hard-coding `align to 1m` (or any constant) over-resolves long ranges and under-resolves short ones.

## Changes

- **`skills/building-dashboards/SKILL.md`**
  - New "🚨 ALIGNMENT RULE" callout in the *Metrics/MPL Blueprint* section with a do/don't example.
  - Documents that the chart `query.apl` does **not** need `param $__interval: Duration;` — the dashboard runtime injects it.
  - Carves out two explicit exceptions: (a) pre-validating with `scripts/metrics/metrics-query` (no dashboard runtime — substitute a concrete duration for the test call only); (b) genuinely sparse metrics where `$__interval` would round to empty buckets (sensors, batch jobs, crons).
  - Updates the *Trends* and *Entity State* bullets and the canonical Metrics/MPL JSON example.
- **`skills/building-dashboards/reference/metrics-mpl.md`** — canonical JSON shape updated; new checklist step enforcing the rule.
- **`skills/building-dashboards/reference/chart-config.md`** — "Metrics Query with Filters and Transformations" example updated.

## Evidence

The change isn't speculative — `$__interval` is already in production use:

- **MPL spec** (`axiom/mpl/spec.md`) documents `param $__interval: Duration;` as the canonical query-parameter pattern.
- **Grafana datasource** (`axiomhq-metrics-datasource`) hard-codes a preamble that declares `$__interval` and `$__rate_interval`, confirming both are first-class MPL variables.
- **Live staging dashboard** `9e80ba6f-bf5a-4852-ba40-96346967e7ae` uses `align to $__interval` in **13 of 16 metrics charts** and renders correctly **without any visible `param` declaration** in the stored `query.apl` — proving the Axiom-native dashboard runtime auto-injects the parameter (not just Grafana). This is what justifies the "no param declaration needed" guidance in the skill.
- The bare `_apl` endpoint rejects `$__interval` without a `param` declaration — justifying the documented pre-validation exception.

## Diff stat

```
 skills/building-dashboards/SKILL.md                  | 19 +++++++++++++++----
 skills/building-dashboards/reference/chart-config.md |  2 +-
 skills/building-dashboards/reference/metrics-mpl.md  |  5 +++--
 3 files changed, 19 insertions(+), 7 deletions(-)
```

## Risk

Documentation-only change. No code, scripts, or tests modified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime code or scripts are modified, but it may change how authors write and validate metrics queries.
> 
> **Overview**
> Adds a **non-negotiable rule** for metrics dashboards: use `align to $__interval` in MPL panel queries so bucket granularity adapts to the dashboard time range and panel width, and clarifies that the dashboard runtime injects the `$__interval` parameter automatically.
> 
> Updates the canonical MPL examples and authoring checklist in `SKILL.md`, `reference/metrics-mpl.md`, and `reference/chart-config.md`, and documents narrow exceptions for CLI pre-validation and genuinely sparse metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4517dfa02db4a452d40567fa5854811c4e9ba709. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->