### PR TITLE
feat(dashboards): MPL parameter values + building-dashboards skill overhaul

### DIFF
--- a/skills/building-dashboards/SKILL.md
+++ b/skills/building-dashboards/SKILL.md
@@ -14,6 +14,7 @@ You design dashboards that help humans make decisions quickly. Dashboards are pr
 3. **Rates and percentiles over averages.** Averages hide problems; p95/p99 expose them.
 4. **Simple beats dense.** One question per panel. No chart junk.
 5. **Validate with data.** Never guess fields—discover schema first.
+6. **Compute what's asked, or defer with a blocker.** Substituting a different quantity Y for the requested X is never acceptable, even with disclosure. If X is blocked, ship a Note panel that documents the blocker. See [Required: Compute What's Asked, or Defer With a Blocker](#required-compute-whats-asked-or-defer-with-a-blocker).
 
 ---
 
@@ -26,6 +27,7 @@ Choose your starting point:
 | **Vague description** | Intake → check dataset kind → design blueprint (APL or MPL) → queries per panel → deploy |
 | **Template** | Pick template → customize dataset/service/env → deploy |
 | **Splunk dashboard** | Extract SPL → translate via spl-to-apl → map to chart types → deploy |
+| **Grafana dashboard** | Project canonical panel spec (`expr`, `legendFormat`, `unit`, `title`, `description`) → translate PromQL → map chart types → deploy. See [reference/grafana-migration.md](./reference/grafana-migration.md). |
 | **Exploration** | Use axiom-sre to discover schema/signals → productize into panels |
 
 ---
@@ -123,7 +125,7 @@ Raw events that answer "what exactly happened?"
 >
 > **No `param` declaration needed in the chart `query.apl`** — the dashboard runtime injects `param $__interval: Duration;` automatically. (The Grafana datasource does the same via a preamble; the Axiom-native dashboard runtime behaves identically.)
 >
-> **🚫 NEVER use inline time ranges in dashboard chart queries.** The dashboard runtime always supplies `start`/`end` over the API on every query. An inline `[1h..]`, `[30d..]`, etc. in the MPL collides with the API range and the backend rejects the query with `AST Error (Time is provided both in the query and as a parameter)`. The dashboard time picker is the user's UI for time control — let it do its job. `overrideDashboardTimeRange: true` does NOT exempt a metrics chart from this rule; the runtime still passes a range.
+> **🚫 NEVER use inline time ranges in dashboard chart queries.** The dashboard runtime always supplies `start`/`end` over the API on every query. An inline `[1h..]`, `[30d..]`, etc. in the MPL collides with the API range and the backend rejects the query with `AST Error (Time is provided both in the query and as a parameter)`. The dashboard time picker is the user's UI for time control — let it do its job. (Per-panel time override is UI-only and has no API field — `overrideDashboardTimeRange` is silently dropped on data charts and rejected on `Note`; see [reference/chart-config.md § Fields Rejected on Create](./reference/chart-config.md#fields-rejected-on-create-cross-chart).)
 >
 > ```mpl
 > `dataset`:metric | align to $__interval using avg          ✅ dashboard panels
@@ -200,6 +202,58 @@ The console uses `react-grid-layout` which requires `minH`, `minW`, `moved`, and
 Use descriptive kebab-case IDs (e.g. `error-rate`, `p95-latency`, `traffic-rps`). The `dashboard-validate` and deploy scripts enforce this automatically.
 
 ---
+
+## Required Chart Unit Configuration
+
+**Every non-Note chart MUST have its unit configured before deploy.** The required field set is asymmetric across chart types — sending the wrong field produces an API rejection (`Unrecognized key: "unit"`), and the most common reaction is to globally strip `unit` from every chart, losing every Statistic's suffix at the same time. Don't react globally; configure per chart type.
+
+| Chart type                                                  | `unit` (enum)            | `customUnits` (suffix)   | Rule                                                                                                                                                            |
+|:------------------------------------------------------------|:------------------------:|:------------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Statistic`                                                  | accepts                  | accepts                  | **Both required.** `unit` formats the value (scaling, abbreviation); `customUnits` paints the suffix string. `unit` alone renders bare numbers (e.g. `Percent100` without `customUnits: "%"` shows `99.5`, not `99.5%`). |
+| `TimeSeries`, `Heatmap`, `Pie`, `Table`, `LogStream`         | **rejected**             | accepts                  | **Only `customUnits`** *plus* encode the unit in the chart `name` (e.g. `"P95 Latency (ms)"`, `"Memory (MB)"`). Sending `unit` returns `Unrecognized key: "unit"`. |
+| `Note`                                                       | n/a                      | n/a                      | Markdown panel — no value to format.                                                                                                                            |
+
+For metrics-backed charts: read the metric's `unit` metadata via `scripts/metrics/metrics-info <deploy> <dataset> metrics <metric> info`, pipe through `scripts/metrics/unit-for`, and splice the result into the chart. **Magnitude conversion happens in MPL** (`| map / 1048576` for bytes → MB; `| map * 100` for 0–1 ratio → percent) — `customUnits` is a label, not a formatter. See [reference/chart-config.md § Unit Configuration](./reference/chart-config.md#unit-configuration-cross-chart) and [reference/metrics-mpl.md § Unit Handling](./reference/metrics-mpl.md#unit-handling) for the full mechanics.
+
+**Pre-deploy check:** every non-Note chart in the dashboard JSON has either (a) `unit` + `customUnits` (Statistic) or (b) `customUnits` and a unit-bearing `name` (everything else). Missing both is a polish failure, not just a cosmetic one — operators can't read magnitudes without context.
+
+---
+
+## Required: Compute What's Asked, or Defer With a Blocker
+
+Every panel asks a specific question. The only acceptable outcomes are:
+
+1. **Compute the requested quantity.** The panel renders the value the source dashboard / spec / user asked for.
+2. **Defer with a documented blocker.** Replace the panel with a `Note` that records what was supposed to be there and why it's blocked. The rest of the dashboard still ships.
+
+**Substituting a different quantity Y is never acceptable, however honestly disclosed.** Labels like "Y replaces X" or "X unavailable; showing Y instead" do not redeem a panel that answers the wrong question — the user reads Y's value and acts on it; the disclaimer doesn't propagate to whoever takes action on the number.
+
+### Defer mechanism: Note panel
+
+The canonical defer mechanism is a `Note` panel in the same layout slot the original panel would have occupied:
+
+```json
+{
+  "id": "availability-deferred",
+  "name": "Availability (deferred)",
+  "type": "Note",
+  "text": "**Deferred — blocked by:** [one-line reason].\n\n**Original spec:** [what the panel was supposed to compute, including the dimension(s) and unit].\n\n**To unblock:** [pointer to the fix, e.g. parser version, missing tag, missing operator]."
+}
+```
+
+Why this beats other options:
+
+- **Don't skip the panel silently.** Omitting it from `charts[]` / `layout[]` ships a dashboard that looks complete but is missing a question the user asked. Deferral is honest; silent omission is not.
+- **Don't use the chart-level `description` field.** It's rejected on create across every chart kind — see [reference/chart-config.md § Fields Rejected on Create](./reference/chart-config.md#fields-rejected-on-create-cross-chart).
+- **Don't bury the blocker in the dashboard-level top `description`.** That field is per-dashboard, not per-panel; readers won't see the blocker next to the deferred slot.
+
+Common blocked-X cases where deferral is the right move:
+
+- The MPL parser doesn't support the ratio computation shape — try the existing ratio blueprint in [reference/promql-to-mpl.md § Ratios and division](./reference/promql-to-mpl.md#ratios-and-division-compute--using-); if it doesn't apply, defer.
+- A required tag is absent from the dataset and reverse-tag discovery finds no equivalent — defer; don't drop the dimension or substitute a different one.
+- The required metric doesn't exist in the dataset and OTel rename rules don't produce one that does — defer; don't render a different metric labelled with the original's name.
+
+See [reference/design-playbook.md § Substituting a Different Quantity](./reference/design-playbook.md#substituting-a-different-quantity-for-the-asked-one) for the full rationale.
 
 ## Metrics/MPL Chart Contract
 
@@ -363,11 +417,24 @@ No APL needed—select monitors from the UI. Shows:
 ### Note
 **When:** Context, instructions, section headers.
 
+Note panels carry their content in a **top-level `text` field** (Markdown). They have no `query`.
+
+```json
+{
+  "id": "header",
+  "name": "API Gateway — Oncall",
+  "type": "Note",
+  "text": "**Purpose:** Quick triage for API incidents.\n\n**Escalation:** Page #platform-oncall if error rate > 5%."
+}
+```
+
 Use GitHub Flavored Markdown for:
 - Dashboard purpose and audience
 - Runbook links
 - Section dividers
 - On-call instructions
+
+**Pitfall:** `text` is a **top-level** chart field, **not** nested in an `options` object. Wrapping it as `options: { text: ... }` is rejected by the create API with `Unrecognized key: "options"`. Grafana text panels use `options.content`; do not carry that shape over.
 
 ---
 
@@ -386,9 +453,9 @@ Charts support JSON configuration options beyond the query. See `reference/chart
 | Note | `text` (markdown), `variant` |
 
 **Common options (all charts):**
-- `overrideDashboardTimeRange`: boolean
-- `overrideDashboardCompareAgainst`: boolean  
 - `hideHeader`: boolean
+
+> **Do not send `overrideDashboardTimeRange` or `overrideDashboardCompareAgainst`.** They are frontend-only fields with no API representation — silently dropped on data charts and rejected on `Note` and `SmartFilter` with `Unrecognized keys` at `[charts <index>]`. See [reference/chart-config.md § Fields Rejected on Create](./reference/chart-config.md#fields-rejected-on-create-cross-chart).
 
 ---
 
@@ -662,8 +729,16 @@ scripts/dashboard-create prod ./dashboard.json
 | `decimals` rejected on create | Create API does not accept chart-level `decimals` even though GET may return it | Omit `decimals` from create payloads |
 | Statistic for an availability/error rate shows `1` instead of `100%` | OTel ratios are 0–1 fractions; `Percent` enum does NOT auto-multiply | `\| map * 100` in MPL, then set `unit: "Percent100"` + `customUnits: "%"`. See [metrics-mpl.md § Percentages and ratios](./reference/metrics-mpl.md#percentages-and-ratios-otel-01-fractions). |
 | Statistic Percent100 renders bare `99.5` instead of `99.5%` | `Percent100` scales the value but does not paint the suffix | Add `customUnits: "%"` alongside `unit: "Percent100"`. |
-| `AST Error (Time is provided both in the query and as a parameter)` on a chart | Inline `[…]` time range in the MPL conflicts with the dashboard runtime's API-supplied `start`/`end`. `overrideDashboardTimeRange: true` does NOT suppress the API range for metrics charts. | Remove the inline range. Dashboards always inherit time from the picker; use `$__interval` for bucketing and let `timeWindowStart`/`timeWindowEnd` (or the user's picker) control the window. |
+| `Unrecognized key: "unit"` on create | Sent the `unit` enum on a non-Statistic chart — TimeSeries, Heatmap, Pie, Table, and LogStream all reject it | Move the suffix to `customUnits` on that chart and encode the unit in the chart `name` (e.g. `"P95 Latency (ms)"`). **Don't react by stripping `unit` from Statistic charts too** — Statistic *needs* both fields. See [Required Chart Unit Configuration](#required-chart-unit-configuration). |
+| `AST Error (Time is provided both in the query and as a parameter)` on a chart | Inline `[…]` time range in the MPL conflicts with the dashboard runtime's API-supplied `start`/`end`. There is no chart-level escape hatch — `overrideDashboardTimeRange` is not a real API field (silently dropped on data charts, rejected on `Note`). | Remove the inline range. Dashboards always inherit time from the picker; use `$__interval` for bucketing and let `timeWindowStart`/`timeWindowEnd` (or the user's picker) control the window. |
+| `Unrecognized keys: "overrideDashboardCompareAgainst", "overrideDashboardTimeRange"` at `[charts N]` on create | A `Note` or `SmartFilter` chart at index N includes one or both of these keys. Data-display chart kinds silently drop them; `Note` and `SmartFilter` reject them. (`SmartFilter` is commonly chart 0 on dashboards with a filter bar, so this often surfaces as `[charts 0]`.) | Strip both keys from every `Note` and `SmartFilter` chart. Best practice: strip from every chart — they have no API effect anywhere. Per-panel time override is UI-only. |
 | `The param $__interval is not defined` from `metrics-query` | The chart query uses `$__interval` but `metrics-query` does not auto-inject the `param` declaration or value the way the dashboard runtime does. | Prepend `param $__interval: Duration;` to the query passed to `metrics-query` and add `-p __interval=5m`. Do NOT rewrite the chart `apl` itself to a fixed duration. |
+| Translated Grafana panel filters or groups on a different subset than the original | Read `expr` but ignored `description` (or vice versa) — both fields carry parts of the panel's spec | Project the canonical panel spec (all five fields together) before authoring MPL. See [reference/grafana-migration.md](./reference/grafana-migration.md). |
+| Metric name from PromQL `expr` not found in the dataset | Hand-rolled guesses instead of applying Prometheus → OTel metric-name rename rules first | Apply rename rules deterministically (drop `_total`, decompose histograms, handle unit suffixes), then validate with `scripts/metrics/metrics-info`. **Label names are not deterministic** — resolve them via reverse-tag discovery, not assumed renaming. See [reference/grafana-migration.md § Name Mapping](./reference/grafana-migration.md#name-mapping-promql--otel-ingest). |
+| Translated MPL chart aggregates across a dimension the PromQL filtered or grouped on | Selector or `by(...)` dimension dropped during PromQL→MPL translation — often because the metric "feels" scoped to the right thing | Every PromQL `{label=…}` becomes a `where`; every `by(…)` dimension becomes a `group by` dimension. See [reference/promql-to-mpl.md](./reference/promql-to-mpl.md). |
+| Panel shipped a different quantity than the one asked for | Author hit a blocker (parser, missing tag, missing metric) and substituted a related quantity instead of deferring — even with a "Y replaces X" disclaimer | If the requested quantity X can't be computed, replace the panel with a `Note` documenting the blocker. Never substitute Y and disclaim it; the disclaimer doesn't propagate to whoever acts on the number. See [Required: Compute What's Asked, or Defer With a Blocker](#required-compute-whats-asked-or-defer-with-a-blocker). |
+| Note panel rejected with `Unrecognized key: "options"` (or `expected string, received undefined` at `[charts N text]`) | Wrapped the Markdown content in `options: { text: ... }`, likely carried over from Grafana text panels (`options.content`) or generalized from Axiom's nested chart options (`tableSettings`, `aggChartOpts`) | `text` is a top-level chart field on Note, never nested. Send `{"type": "Note", "text": "…"}` directly. The `options` key is rejected on every chart kind, not just Note. See [Note](#note) and [reference/chart-config.md § Fields Rejected on Create](./reference/chart-config.md#fields-rejected-on-create-cross-chart). |
+| OTel histogram chart shows nonsense values (`align to … using avg` on a histogram metric) | Histogram translated as a scalar — `histogram_quantile(...)` was not mapped to `bucket … using interpolate_*_histogram` | Read the metric `type` from `metrics-info … metrics <m> info`; use `interpolate_cumulative_histogram` (cumulative) or `interpolate_delta_histogram` (delta) based on the metric's temporality. See [reference/promql-to-mpl.md § Histogram translation](./reference/promql-to-mpl.md#histogram-translation-histogram_quantile--bucket--using-interpolate__histogram). |
 
 ---
 
@@ -675,6 +750,8 @@ scripts/dashboard-create prod ./dashboard.json
 - `reference/chart-cookbook.md` — APL patterns per chart type
 - `reference/layout-recipes.md` — Grid layouts and section blueprints
 - `reference/splunk-migration.md` — Splunk panel → Axiom mapping
+- `reference/grafana-migration.md` — Grafana panel → Axiom mapping (canonical-spec projection, PromQL→MPL pointers, OTel rename rules)
+- `reference/promql-to-mpl.md` — PromQL → MPL translation rules (selectors, groupings, rate, histograms, ratios, reverse-tag discovery)
 - `reference/design-playbook.md` — Decision-first design principles
 - `reference/templates/` — Ready-to-use dashboard JSON files
 

--- a/skills/building-dashboards/SKILL.md
+++ b/skills/building-dashboards/SKILL.md
@@ -129,15 +129,14 @@ Raw events that answer "what exactly happened?"
 Current values for key metrics — answer "what's the state right now?"
 - Latest value of primary metrics (e.g., current temperature, power draw)
 - Use `group using avg` or `group using last` depending on metric type (gauge vs counter)
-- **Set the chart unit from metric metadata.** Run `scripts/metrics/metrics-info <deploy> <dataset> metrics <metric> info` to read the metric's `unit`, then pipe it through `scripts/metrics/unit-for` to get the right `unit`/`customUnits` block to splice into the chart. See [reference/metrics-mpl.md § Unit Handling](./reference/metrics-mpl.md#unit-handling).
-- **Percentages from OTel/Prometheus ratios (0–1 fractions): multiply by 100 in MPL AND set both `unit: "Percent100"` and `customUnits: "%"`.** A `compute … using /` ratio or any 0–1 fraction must end with `| map * 100` before `| align`. On the Statistic chart, set BOTH `"unit": "Percent100"` (scales the value) AND `"customUnits": "%"` (paints the `%` suffix); `Percent100` alone renders bare `99.5`. The `Percent` enum does NOT auto-scale 0–1 → 0–100 (`1.0` renders as bare `1`), so don't use it for OTel ratios. See [reference/metrics-mpl.md § Percentages and ratios](./reference/metrics-mpl.md#percentages-and-ratios-otel-01-fractions).
+- **Set the chart unit from metric metadata.** Run `scripts/metrics/metrics-info <deploy> <dataset> metrics <metric> info`, pipe the resulting `unit` through `scripts/metrics/unit-for`, and splice the JSON block into the chart. For OTel ratio metrics (0–1 fractions), multiply by 100 in MPL before aligning. See [reference/metrics-mpl.md § Unit Handling](./reference/metrics-mpl.md#unit-handling).
 
 #### 2. Trends (TimeSeries panels)
 Metric trends over time — answer "what changed?"
 - Primary metrics over time, grouped by key dimension
 - Use `align to $__interval using avg|sum|last` for proper time bucketing — `$__interval` is supplied by the dashboard runtime
 - Group by low-cardinality tags only (≤10 series per chart)
-- **TimeSeries (and Heatmap/Pie/Table/LogStream) accept `customUnits` at the API level but the `unit` enum is rejected.** Always also encode the unit in the chart `name` (e.g. `"P95 Latency (ms)"`, `"Memory (MB)"`) so the header is self-describing. For magnitude conversion, scale in MPL (`| map / 1048576` for bytes → MB). See [reference/chart-config.md § Unit Configuration](./reference/chart-config.md#unit-configuration-cross-chart).
+- **Encode the unit in the chart `name`** (e.g. `"P95 Latency (ms)"`, `"Memory (MB)"`) — non-Statistic charts reject the `unit` enum, so the header label is the primary unit signal. Scale magnitudes in MPL (`| map / 1048576` for bytes → MB). See [reference/chart-config.md § Unit Configuration](./reference/chart-config.md#unit-configuration-cross-chart).
 
 #### 3. Breakdowns (TimeSeries or Table panels)
 Per-entity detail — answer "where should I look?"
@@ -641,8 +640,8 @@ scripts/dashboard-create prod ./dashboard.json
 | Metrics chart renders blank or wrong values | Missing `query.metricsDataset` — backend treats `apl` as APL, not MPL | Set `query.metricsDataset` to the dataset name alongside `query.apl` |
 | `query.mpl` rejected on create | GET may return `query.mpl` for existing metrics charts, but create expects `query.apl` | Move/copy the MPL string into `query.apl` before deploy |
 | `decimals` rejected on create | Create API does not accept chart-level `decimals` even though GET may return it | Omit `decimals` from create payloads |
-| Statistic panel for an availability/error rate shows `1` instead of `100%` (or `0.05` instead of `5%`) | OTel ratios are 0–1 fractions; the Axiom `Percent` enum does NOT auto-multiply by 100 | Multiply in MPL with `\| map * 100` before `\| align`, and set BOTH `"unit": "Percent100"` and `"customUnits": "%"` on the chart. See [reference/metrics-mpl.md § Percentages and ratios](./reference/metrics-mpl.md#percentages-and-ratios-otel-01-fractions). |
-| Statistic Percent100 panel renders bare `99.5` instead of `99.5%` | `unit: "Percent100"` scales the value to 0–100 but does NOT paint the `%` suffix | Add `"customUnits": "%"` alongside the existing `"unit": "Percent100"`. |
+| Statistic for an availability/error rate shows `1` instead of `100%` | OTel ratios are 0–1 fractions; `Percent` enum does NOT auto-multiply | `\| map * 100` in MPL, then set `unit: "Percent100"` + `customUnits: "%"`. See [metrics-mpl.md § Percentages and ratios](./reference/metrics-mpl.md#percentages-and-ratios-otel-01-fractions). |
+| Statistic Percent100 renders bare `99.5` instead of `99.5%` | `Percent100` scales the value but does not paint the suffix | Add `customUnits: "%"` alongside `unit: "Percent100"`. |
 
 ---
 

--- a/skills/building-dashboards/SKILL.md
+++ b/skills/building-dashboards/SKILL.md
@@ -5,8 +5,6 @@ description: Designs and builds Axiom dashboards via API. Covers chart types, AP
 
 # Building Dashboards
 
-You design dashboards that help humans make decisions quickly. Dashboards are products: audience, questions, and actions matter more than chart count.
-
 ## Philosophy
 
 1. **Decisions first.** Every panel answers a question that leads to an action.
@@ -14,13 +12,11 @@ You design dashboards that help humans make decisions quickly. Dashboards are pr
 3. **Rates and percentiles over averages.** Averages hide problems; p95/p99 expose them.
 4. **Simple beats dense.** One question per panel. No chart junk.
 5. **Validate with data.** Never guess fields—discover schema first.
-6. **Compute what's asked, or defer with a blocker.** Substituting a different quantity Y for the requested X is never acceptable, even with disclosure. If X is blocked, ship a Note panel that documents the blocker. See [Required: Compute What's Asked, or Defer With a Blocker](#required-compute-whats-asked-or-defer-with-a-blocker).
+6. **Compute what's asked, or defer.** If a panel can't be computed, replace it with a `Note` documenting the blocker. Never substitute a different quantity, even disclosed. See [Compute or Defer](#compute-or-defer).
 
 ---
 
 ## Entry Points
-
-Choose your starting point:
 
 | Starting from | Workflow |
 |---------------|----------|
@@ -34,8 +30,6 @@ Choose your starting point:
 
 ## Intake: What to Ask First
 
-Before designing, clarify:
-
 1. **Audience & decision**
    - Oncall triage? (fast refresh, error-focused)
    - Team health? (daily trends, SLO tracking)
@@ -45,28 +39,20 @@ Before designing, clarify:
    - Service, environment, region, cluster, endpoint?
    - Single service or cross-service view?
 
-3. **Dataset kind (mandatory first step)**
-   - Run `scripts/metrics/datasets <deploy>` to identify each dataset's `kind`
-   - **If `kind` is `otel:metrics:v1`** → this is a metrics dataset. Follow the **Metrics path** below.
-   - **Otherwise** → this is an events/logs dataset. Follow the **APL path** below.
+3. **Dataset kind.** Run `scripts/metrics/datasets <deploy>` and check `kind`.
+   - `otel:metrics:v1` → metrics dataset, follow the **Metrics path**.
+   - anything else → events/logs dataset, follow the **APL path**.
 
-   > **⚠️ NEVER run `getschema` on a metrics dataset.** APL queries against `otel:metrics:v1` datasets return 0 rows without error — you will waste calls widening time ranges before realizing it's the wrong discovery method.
+   > **Never run `getschema` on a metrics dataset.** It returns 0 rows without error.
 
-   **APL path** (events/logs datasets):
-   - Discover fields with `getschema`:
-   ```apl
-   ['dataset'] | where _time between (ago(1h) .. now()) | getschema
-   ```
-   - Continue to steps 4–5 below.
+   **APL path:** discover fields with `['dataset'] | where _time between (ago(1h) .. now()) | getschema`. Continue to steps 4–5.
 
-   **Metrics path** (`otel:metrics:v1` datasets):
-   - Run `scripts/metrics/metrics-spec <deploy> <dataset>` — **mandatory before composing any MPL query**
-   - Discover available metrics: `scripts/metrics/metrics-info <deploy> <dataset> metrics`
-   - Discover tags: `scripts/metrics/metrics-info <deploy> <dataset> tags`
-   - Explore tag values: `scripts/metrics/metrics-info <deploy> <dataset> tags <tag> values`
-   - If discovery returns empty results, retry with `--start` set to 7 days ago — sparse metrics (sensors, batch jobs, crons) may not have data in the default 24h window
-   - `find-metrics <value>` searches **tag values**, not metric names — use it only when you know a specific entity name (service, host, device) to find which metrics are associated with it
-   - Skip to the **Metrics/MPL Blueprint** below for panel design.
+   **Metrics path:**
+   - `scripts/metrics/metrics-spec <deploy> <dataset>` — required before any MPL query.
+   - `scripts/metrics/metrics-info <deploy> <dataset> metrics | tags | tags <tag> values` for discovery.
+   - If discovery is empty, retry with `--start` 7 days ago (sparse metrics).
+   - `find-metrics <value>` searches tag *values*, not metric names — use it only with a known entity name.
+   - Skip to the **Metrics/MPL Blueprint**.
 
 4. **Golden signals** (APL path)
    - Traffic: requests/sec, events/min
@@ -81,7 +67,7 @@ Before designing, clarify:
 
 ## Dashboard Blueprint
 
-Choose the blueprint that matches your dataset kind (identified in Intake step 3).
+Pick the blueprint matching the dataset kind.
 
 ### APL Blueprint (events/logs datasets)
 
@@ -114,397 +100,106 @@ Raw events that answer "what exactly happened?"
 
 ### Metrics/MPL Blueprint (metrics datasets)
 
-> **Prerequisite:** You MUST have run `scripts/metrics/metrics-spec` and `scripts/metrics/metrics-info` before designing panels. Never guess MPL syntax or metric/tag names.
+Use `align to $__interval using …` for bucketing — `$__interval` is supplied by the dashboard runtime. Hard-coded windows over- or under-resolve. Validate every pipeline with `scripts/metrics/mpl-validate-chart`; both it and `chart-add --mpl` reject inline time ranges (`[1h..]`).
 
-> **🚨 ALIGNMENT RULE — non-negotiable for dashboard panels:** Always align to the dashboard-supplied variable `$__interval`, not a fixed window. The dashboard runtime substitutes `$__interval` based on the active time range and panel width, so the same chart stays usable from a 5-minute to a 30-day view. Hard-coding `align to 1m` (or any constant) over-resolves long ranges and under-resolves short ones.
->
-> ```mpl
-> | align to $__interval using avg   ✅ dashboard panels
-> | align to 1m using avg            ❌ fixed window — wrong granularity at most time ranges
-> ```
->
-> **No `param` declaration needed in the chart `query.apl`** — the dashboard runtime injects `param $__interval: Duration;` automatically. (The Grafana datasource does the same via a preamble; the Axiom-native dashboard runtime behaves identically.)
->
-> **🚫 NEVER use inline time ranges in dashboard chart queries.** The dashboard runtime always supplies `start`/`end` over the API on every query. An inline `[1h..]`, `[30d..]`, etc. in the MPL collides with the API range and the backend rejects the query with `AST Error (Time is provided both in the query and as a parameter)`. The dashboard time picker is the user's UI for time control — let it do its job. (Per-panel time override is UI-only and has no API field — `overrideDashboardTimeRange` is silently dropped on data charts and rejected on `Note`; see [reference/chart-config.md § Fields Rejected on Create](./reference/chart-config.md#fields-rejected-on-create-cross-chart).)
->
-> ```mpl
-> `dataset`:metric | align to $__interval using avg          ✅ dashboard panels
-> `dataset`:metric[30d..] | align to 30d using avg          ❌ inline range — AST time conflict
-> ```
->
-> **Pre-validating chart queries with `scripts/metrics/metrics-query`:** the dashboard runtime auto-declares `param $__interval: Duration;` AND supplies its value via the request body. `metrics-query` does NOT auto-inject either. To simulate the runtime exactly, prepend `param $__interval: Duration;` to the test query and pass `-p __interval=5m` (or any concrete duration the dashboard would pick) on the command line. Do NOT rewrite the chart's `apl` to a fixed duration just to make the test pass — that hides whether the deployed chart will work.
->
-> ```bash
-> # ✅ correct — keep $__interval, simulate the runtime injection
-> scripts/metrics/metrics-query -p __interval=5m <deploy> \
->   'param $__interval: Duration;
-> `dataset`:metric | align to $__interval using avg' now-1h now
->
-> # ❌ wrong — silently rewriting to `5m` only proves the fixed-duration form works
-> scripts/metrics/metrics-query <deploy> \
->   '`dataset`:metric | align to 5m using avg' now-1h now
-> ```
->
-> **Exceptions:** for genuinely sparse metrics where `$__interval` would round to an empty bucket (sensors, batch jobs, crons), a fixed wider window (e.g. `1h`) is acceptable in the committed chart JSON; document why in the chart description.
+Exception: for sparse metrics where `$__interval` rounds to empty buckets, a fixed wider window (e.g. `1h`) is acceptable; document why on the chart.
 
 #### 1. At-a-Glance (Statistic panels)
-Current values for key metrics — answer "what's the state right now?"
-- Latest value of primary metrics (e.g., current temperature, power draw)
-- Use `group using avg` or `group using last` depending on metric type (gauge vs counter)
-- **Set the chart unit from metric metadata.** Run `scripts/metrics/metrics-info <deploy> <dataset> metrics <metric> info`, pipe the resulting `unit` through `scripts/metrics/unit-for`, and splice the JSON block into the chart. For OTel ratio metrics (0–1 fractions), multiply by 100 in MPL before aligning. See [reference/metrics-mpl.md § Unit Handling](./reference/metrics-mpl.md#unit-handling).
+Current values — "what's the state right now?"
+- Use `group using avg` (gauges) or `group using last` (counters).
+- Read the metric's `unit` via `metrics-info … metrics <m> info` and pass it to `chart-add --unit`. Ratio metrics (0–1) need `| map * 100` in MPL before `--unit "%"`.
 
 #### 2. Trends (TimeSeries panels)
-Metric trends over time — answer "what changed?"
-- Primary metrics over time, grouped by key dimension
-- Use `align to $__interval using avg|sum|last` for proper time bucketing — `$__interval` is supplied by the dashboard runtime
-- Group by low-cardinality tags only (≤10 series per chart)
-- **Encode the unit in the chart `name`** (e.g. `"P95 Latency (ms)"`, `"Memory (MB)"`) — non-Statistic charts reject the `unit` enum, so the header label is the primary unit signal. Scale magnitudes in MPL (`| map / 1048576` for bytes → MB). See [reference/chart-config.md § Unit Configuration](./reference/chart-config.md#unit-configuration-cross-chart).
+Trends over time — "what changed?"
+- `align to $__interval using avg|sum|last`.
+- Group by low-cardinality tags only (≤10 series per chart).
+- Embed the unit in `--name` (`"P95 Latency (ms)"`, `"Memory (MiB)"`); scale magnitudes in MPL (`| map / 1048576` for bytes → MiB).
 
 #### 3. Breakdowns (TimeSeries or Table panels)
-Per-entity detail — answer "where should I look?"
-- Metrics broken down by entity (room, host, pod, service)
-- Filter by tag values to keep series count manageable
-- Use separate panels per dimension rather than one overloaded chart
+Per-entity detail — "where should I look?"
+- Metrics broken down by entity (host, pod, service).
+- Filter to keep series count manageable.
+- One dimension per panel; don't overload a single chart.
 
 #### 4. Entity State (TimeSeries or Table panels)
 Boolean/state metrics — answer "what is on/off/active?"
-- Use `align to $__interval using last` for state metrics
-- Sparse metrics may need wider **fixed** align intervals (1h+) to show data — this is the documented exception to the `$__interval` rule
-
----
-
-## Layout Auto-Normalization
-
-The console uses `react-grid-layout` which requires `minH`, `minW`, `moved`, and `static` on every layout entry. The `dashboard-create` and `dashboard-update` scripts auto-fill these if omitted, so layout entries only need `i`, `x`, `y`, `w`, `h`.
+- Use `align to $__interval using last`.
+- Sparse state metrics may need a fixed wider interval (1h+).
 
 ---
 
 ## Required Chart Structure
 
-**Every chart MUST have a unique `id` field.** Every layout entry's `i` field MUST reference a chart `id`. Missing or mismatched IDs will corrupt the dashboard in the UI (blank state, unable to save/revert).
-
-```json
-{
-  "charts": [
-    {
-      "id": "error-rate",
-      "name": "Error Rate",
-      "type": "Statistic",
-      "query": { "apl": "..." }
-    }
-  ],
-  "layout": [
-    {"i": "error-rate", "x": 0, "y": 0, "w": 3, "h": 2}
-  ]
-}
-```
-
-Use descriptive kebab-case IDs (e.g. `error-rate`, `p95-latency`, `traffic-rps`). The `dashboard-validate` and deploy scripts enforce this automatically.
+Each chart needs a unique kebab-case `id` (`error-rate`, `p95-latency`); every layout `i` must match one. Pass the same id to `chart-add --id` and `layout-pack <id>:…`. `dashboard-assemble` cross-checks before emit.
 
 ---
 
-## Required Chart Unit Configuration
+## Chart Unit Configuration
 
-**Every non-Note chart MUST have its unit configured before deploy.** The required field set is asymmetric across chart types — sending the wrong field produces an API rejection (`Unrecognized key: "unit"`), and the most common reaction is to globally strip `unit` from every chart, losing every Statistic's suffix at the same time. Don't react globally; configure per chart type.
-
-| Chart type                                                  | `unit` (enum)            | `customUnits` (suffix)   | Rule                                                                                                                                                            |
-|:------------------------------------------------------------|:------------------------:|:------------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `Statistic`                                                  | accepts                  | accepts                  | **Both required.** `unit` formats the value (scaling, abbreviation); `customUnits` paints the suffix string. `unit` alone renders bare numbers (e.g. `Percent100` without `customUnits: "%"` shows `99.5`, not `99.5%`). |
-| `TimeSeries`, `Heatmap`, `Pie`, `Table`, `LogStream`         | **rejected**             | accepts                  | **Only `customUnits`** *plus* encode the unit in the chart `name` (e.g. `"P95 Latency (ms)"`, `"Memory (MB)"`). Sending `unit` returns `Unrecognized key: "unit"`. |
-| `Note`                                                       | n/a                      | n/a                      | Markdown panel — no value to format.                                                                                                                            |
-
-For metrics-backed charts: read the metric's `unit` metadata via `scripts/metrics/metrics-info <deploy> <dataset> metrics <metric> info`, pipe through `scripts/metrics/unit-for`, and splice the result into the chart. **Magnitude conversion happens in MPL** (`| map / 1048576` for bytes → MB; `| map * 100` for 0–1 ratio → percent) — `customUnits` is a label, not a formatter. See [reference/chart-config.md § Unit Configuration](./reference/chart-config.md#unit-configuration-cross-chart) and [reference/metrics-mpl.md § Unit Handling](./reference/metrics-mpl.md#unit-handling) for the full mechanics.
-
-**Pre-deploy check:** every non-Note chart in the dashboard JSON has either (a) `unit` + `customUnits` (Statistic) or (b) `customUnits` and a unit-bearing `name` (everything else). Missing both is a polish failure, not just a cosmetic one — operators can't read magnitudes without context.
+Pass a friendly unit string to `chart-add --unit` (`"%"`, `"s"`, `"ms"`, `"B"`, `"req/s"`). The script picks `unit` enum + `customUnits` suffix per chart type. `customUnits` is a label, not a formatter — scale magnitudes in MPL (`| map / 1048576` for bytes → MiB, `| map / 1000000` for bytes → MB, `| map * 100` for 0–1 ratio → percent). For metrics charts, read the source unit from `metrics-info … metrics <m> info` and pass it through. Internals (advanced options the agent may merge with `jq`): [reference/chart-config.md](./reference/chart-config.md).
 
 ---
 
-## Required: Compute What's Asked, or Defer With a Blocker
+## Compute or Defer
 
-Every panel asks a specific question. The only acceptable outcomes are:
+Each panel either computes the requested quantity, or it's replaced by a `Note` documenting the blocker. Substituting a different quantity is never acceptable — disclaimers don't reach whoever acts on the number.
 
-1. **Compute the requested quantity.** The panel renders the value the source dashboard / spec / user asked for.
-2. **Defer with a documented blocker.** Replace the panel with a `Note` that records what was supposed to be there and why it's blocked. The rest of the dashboard still ships.
+Defer template (use `chart-add --type Note`):
 
-**Substituting a different quantity Y is never acceptable, however honestly disclosed.** Labels like "Y replaces X" or "X unavailable; showing Y instead" do not redeem a panel that answers the wrong question — the user reads Y's value and acts on it; the disclaimer doesn't propagate to whoever takes action on the number.
+```
+**Deferred — blocked by:** <one-line reason>.
 
-### Defer mechanism: Note panel
+**Original spec:** <what the panel should compute, dimensions, unit>.
 
-The canonical defer mechanism is a `Note` panel in the same layout slot the original panel would have occupied:
-
-```json
-{
-  "id": "availability-deferred",
-  "name": "Availability (deferred)",
-  "type": "Note",
-  "text": "**Deferred — blocked by:** [one-line reason].\n\n**Original spec:** [what the panel was supposed to compute, including the dimension(s) and unit].\n\n**To unblock:** [pointer to the fix, e.g. parser version, missing tag, missing operator]."
-}
+**To unblock:** <pointer to the fix>.
 ```
 
-Why this beats other options:
-
-- **Don't skip the panel silently.** Omitting it from `charts[]` / `layout[]` ships a dashboard that looks complete but is missing a question the user asked. Deferral is honest; silent omission is not.
-- **Don't use the chart-level `description` field.** It's rejected on create across every chart kind — see [reference/chart-config.md § Fields Rejected on Create](./reference/chart-config.md#fields-rejected-on-create-cross-chart).
-- **Don't bury the blocker in the dashboard-level top `description`.** That field is per-dashboard, not per-panel; readers won't see the blocker next to the deferred slot.
-
-Common blocked-X cases where deferral is the right move:
-
-- The MPL parser doesn't support the ratio computation shape — try the existing ratio blueprint in [reference/promql-to-mpl.md § Ratios and division](./reference/promql-to-mpl.md#ratios-and-division-compute--using-); if it doesn't apply, defer.
-- A required tag is absent from the dataset and reverse-tag discovery finds no equivalent — defer; don't drop the dimension or substitute a different one.
-- The required metric doesn't exist in the dataset and OTel rename rules don't produce one that does — defer; don't render a different metric labelled with the original's name.
-
-See [reference/design-playbook.md § Substituting a Different Quantity](./reference/design-playbook.md#substituting-a-different-quantity-for-the-asked-one) for the full rationale.
-
-## Metrics/MPL Chart Contract
-
-Metrics-backed charts require both `query.apl` (the MPL pipeline string) and `query.metricsDataset` (the dataset name). The `metricsDataset` field is what tells the backend to interpret `apl` as MPL rather than APL — omitting it causes the chart to misbehave even if the pipeline string is well-formed.
-
-> **CRITICAL:** Run `scripts/metrics/metrics-spec <deployment> <dataset>` before composing your first MPL query in a session. NEVER guess MPL syntax.
->
-> **API gotcha:** Set `query.metricsDataset` to the dataset name (e.g. `"otel-metrics"`). The create API rejects `query.mpl` even though GET responses for existing metrics dashboards may include it — put the MPL string in `query.apl` instead.
-
-```json
-{
-  "type": "TimeSeries",
-  "query": {
-    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| align to $__interval using avg\n| group by `service.name` using avg",
-    "metricsDataset": "otel-metrics"
-  }
-}
-```
-
-Validate queries with `scripts/metrics/metrics-query` before embedding in dashboard JSON.
-
-See `reference/metrics-mpl.md` for the full contract and discovery scripts.
+Common blockers: MPL parser limits, missing tag with no reverse-tag equivalent, missing metric with no OTel rename match. Full rationale: [reference/design-playbook.md § Substituting a Different Quantity](./reference/design-playbook.md#substituting-a-different-quantity-for-the-asked-one).
 
 ---
 
 ## Chart Types
 
-**Note:** Dashboard queries inherit time from the UI picker—no explicit `_time` filter needed.
+| Type          | When                                                | Key constraint                                                       |
+|---------------|-----------------------------------------------------|----------------------------------------------------------------------|
+| Statistic     | Single KPI, current value                           | Query must return one row.                                           |
+| TimeSeries    | Trends over time, percentile overlays               | `bin_auto(_time)`; `percentiles_array()` for multi-percentile.       |
+| Table         | Top-N lists, breakdowns                             | Bound with `top N`; control columns via `project`.                   |
+| Pie           | Share-of-total for ≤6 categories                    | Aggregate to ≤6 slices; never high-cardinality.                      |
+| LogStream     | Raw event inspection                                | `take 100–500`; `project-keep` to relevant fields; filter hard.      |
+| Heatmap       | Distribution / latency density                      | `summarize histogram(field, buckets) by bin_auto(_time)`.            |
+| Scatter Plot  | Correlate two metrics per group                     | `summarize avg(x), avg(y) by group`.                                 |
+| SmartFilter   | Interactive filter bar                              | Each panel query needs `declare query_parameters`. See `reference/smartfilter.md`. |
+| Monitor List  | Monitor status display                              | No APL — select monitors in UI.                                      |
+| Note          | Markdown context, headers, runbook links            | `chart-add --type Note --text "<md>"`.                               |
 
-**Validation:** TimeSeries, Statistic, Table, Pie, LogStream, Note, MonitorList are fully validated by `dashboard-validate`. Heatmap, ScatterPlot, SmartFilter work but may trigger warnings.
-
-### Statistic
-**When:** Single KPI, current value, threshold comparison.
-
-```apl
-['logs']
-| where service == "api"
-| summarize 
-    total = count(),
-    errors = countif(status >= 500)
-| extend error_rate = round(100.0 * errors / total, 2)
-| project error_rate
-```
-
-**Pitfalls:** Don't use for time series; ensure query returns single row.
-
-### TimeSeries
-**When:** Trends over time, before/after comparison, rate changes.
-
-```apl
-// Single metric - use bin_auto for automatic sizing
-['logs']
-| summarize ['req/min'] = count() by bin_auto(_time)
-
-// Latency percentiles - use percentiles_array for proper overlay
-['logs']
-| summarize percentiles_array(duration_ms, 50, 95, 99) by bin_auto(_time)
-```
-
-**Best practices:**
-- Use `bin_auto(_time)` instead of fixed `bin(_time, 1m)` — auto-adjusts to time window
-- Use `percentiles_array()` instead of multiple `percentile()` calls — renders as one chart
-- Too many series = unreadable; use `top N` or filter
-
-### Table
-**When:** Top-N lists, detailed breakdowns, exportable data.
-
-```apl
-['logs']
-| where status >= 500
-| summarize errors = count() by route, error_message
-| top 10 by errors
-| project route, error_message, errors
-```
-
-**Pitfalls:**
-- Always use `top N` to prevent unbounded results
-- Use `project` to control column order and names
-
-### Pie
-**When:** Share-of-total for LOW cardinality dimensions (≤6 slices).
-
-```apl
-['logs']
-| summarize count() by status_class = case(
-    status < 300, "2xx",
-    status < 400, "3xx",
-    status < 500, "4xx",
-    "5xx"
-  )
-```
-
-**Pitfalls:**
-- Never use for high cardinality (routes, user IDs)
-- Prefer tables for >6 categories
-- Always aggregate to reduce slices
-
-### LogStream
-**When:** Raw event inspection, debugging, evidence gathering.
-
-```apl
-['logs']
-| where service == "api" and status >= 500
-| project-keep _time, trace_id, route, status, error_message, duration_ms
-| take 100
-```
-
-**Pitfalls:**
-- Always include `take N` (100-500 max)
-- Use `project-keep` to show relevant fields only
-- Filter aggressively—raw logs are expensive
-
-### Heatmap
-**When:** Distribution visualization, latency patterns, density analysis.
-
-```apl
-['logs']
-| summarize histogram(duration_ms, 15) by bin_auto(_time)
-```
-
-**Best for:** Latency distributions, response time patterns, identifying outliers.
-
-### Scatter Plot
-**When:** Correlation between two metrics, identifying patterns.
-
-```apl
-['logs']
-| summarize avg(duration_ms), avg(resp_size_bytes) by route
-```
-
-**Best for:** Response size vs latency correlation, resource usage patterns.
-
-### SmartFilter (Filter Bar)
-**When:** Interactive filtering for the entire dashboard.
-
-SmartFilter is a **chart type** that creates dropdown/search filters. Requires:
-1. A `SmartFilter` chart with filter definitions
-2. `declare query_parameters` in each panel query
-
-**Filter types:**
-- `selectType: "apl"` — Dynamic dropdown from APL query
-- `selectType: "list"` — Static dropdown with predefined options
-- `type: "search"` — Free-text input
-
-**Panel query pattern:**
-```apl
-declare query_parameters (country_filter:string = "");
-['logs'] | where isempty(country_filter) or ['geo.country'] == country_filter
-```
-
-See `reference/smartfilter.md` for full JSON structure and cascading filter examples.
-
-### Monitor List
-**When:** Display monitor status on operational dashboards.
-
-No APL needed—select monitors from the UI. Shows:
-- Monitor status (normal/triggered/off)
-- Run history (green/red squares)
-- Dataset, type, notifiers
-
-### Note
-**When:** Context, instructions, section headers.
-
-Note panels carry their content in a **top-level `text` field** (Markdown). They have no `query`.
-
-```json
-{
-  "id": "header",
-  "name": "API Gateway — Oncall",
-  "type": "Note",
-  "text": "**Purpose:** Quick triage for API incidents.\n\n**Escalation:** Page #platform-oncall if error rate > 5%."
-}
-```
-
-Use GitHub Flavored Markdown for:
-- Dashboard purpose and audience
-- Runbook links
-- Section dividers
-- On-call instructions
-
-**Pitfall:** `text` is a **top-level** chart field, **not** nested in an `options` object. Wrapping it as `options: { text: ... }` is rejected by the create API with `Unrecognized key: "options"`. Grafana text panels use `options.content`; do not carry that shape over.
+Per-type APL recipes: `reference/chart-cookbook.md`.
 
 ---
 
 ## Chart Configuration
 
-Charts support JSON configuration options beyond the query. See `reference/chart-config.md` for full details.
-
-**Quick reference:**
-
-| Chart Type | Key Options |
-|------------|-------------|
-| Statistic | `colorScheme`, `customUnits`, `unit`, `showChart` (sparkline), `errorThreshold`/`warningThreshold` |
-| TimeSeries | `aggChartOpts`: `variant` (line/area/bars), `scaleDistr` (linear/log), `displayNull` |
-| LogStream/Table | `tableSettings`: `columns`, `fontSize`, `highlightSeverity`, `wrapLines` |
-| Pie | `hideHeader` |
-| Note | `text` (markdown), `variant` |
-
-**Common options (all charts):**
-- `hideHeader`: boolean
-
-> **Do not send `overrideDashboardTimeRange` or `overrideDashboardCompareAgainst`.** They are frontend-only fields with no API representation — silently dropped on data charts and rejected on `Note` and `SmartFilter` with `Unrecognized keys` at `[charts <index>]`. See [reference/chart-config.md § Fields Rejected on Create](./reference/chart-config.md#fields-rejected-on-create-cross-chart).
+`chart-add` covers the common path (type, id, name, query, dataset, unit, sparkline). For options it doesn't expose — `aggChartOpts` variants on TimeSeries, `tableSettings.columns` on Table/LogStream, `hideHeader`, etc. — start from a `chart-add` output and merge the extra fields with `jq`. See `reference/chart-config.md` for the full option set, and the rejected-field list before merging anything bespoke.
 
 ---
 
 ## APL Patterns
 
-### Time Filtering in Dashboards vs Ad-hoc Queries
+### Time Filtering
 
-**Dashboard panel queries do NOT need explicit time filters.** The dashboard UI time picker automatically scopes all queries to the selected time window.
-
-```apl
-// DASHBOARD QUERY — no time filter needed
-['logs']
-| where service == "api"
-| summarize count() by bin_auto(_time)
-```
-
-**Ad-hoc queries (Axiom Query tab, axiom-sre exploration) MUST have explicit time filters:**
-
-```apl
-// AD-HOC QUERY — always include time filter
-['logs']
-| where _time between (ago(1h) .. now())
-| where service == "api"
-| summarize count() by bin_auto(_time)
-```
+Dashboard chart queries inherit time from the picker — omit `_time` filters. Ad-hoc queries (Axiom Query tab, `axiom-sre`) need an explicit `where _time between (ago(1h) .. now())`.
 
 ### Bin Size Selection
 
-**Prefer `bin_auto(_time)`** — it automatically adjusts to the dashboard time window.
-
-Manual bin sizes (only when auto doesn't fit your needs):
-
-| Time window | Bin size |
-|-------------|----------|
-| 15m | 10s–30s |
-| 1h | 1m |
-| 6h | 5m |
-| 24h | 15m–1h |
-| 7d | 1h–6h |
+Use `bin_auto(_time)` — it adjusts to the dashboard time window. Manual `bin(_time, …)` is only justified for non-standard cases (e.g. matching an upstream batch interval); document why.
 
 ### Cardinality Guardrails
-Prevent query explosion:
+
+Bound `summarize … by …` with `top N` or a filter. Unbounded grouping on high-cardinality fields (`user_id`, `trace_id`) blows up.
 
 ```apl
-// GOOD: bounded
-| summarize count() by route | top 10 by count_
-
-// BAD: unbounded high-cardinality grouping
-| summarize count() by user_id  // millions of rows
+| summarize count() by route | top 10 by count_   // bounded
+| summarize count() by user_id                    // unbounded — avoid
 ```
 
 ### Field Escaping
@@ -520,71 +215,27 @@ Fields with dots IN the name (not hierarchy) need escaping:
 | where ['kubernetes.labels.app\\.kubernetes\\.io/name'] == "frontend"
 ```
 
-### Golden Signal Queries
+### Recipes
 
-**Traffic:**
-```apl
-| summarize requests = count() by bin_auto(_time)
-```
-
-**Errors (as rate %):**
-```apl
-| summarize total = count(), errors = countif(status >= 500) by bin_auto(_time)
-| extend error_rate = iff(total > 0, round(100.0 * errors / total, 2), 0.0)
-| project _time, error_rate
-```
-
-**Latency (use percentiles_array for proper chart overlay):**
-```apl
-| summarize percentiles_array(duration_ms, 50, 95, 99) by bin_auto(_time)
-```
+Traffic, error-rate, latency-percentile, and other golden-signal APL recipes: `reference/chart-cookbook.md`.
 
 ---
 
 ## Layout Composition
 
-### Grid Principles
-- Dashboard width = 12 units
-- Typical panel: w=3 (quarter), w=4 (third), w=6 (half), w=12 (full)
-- Stats row: 4 panels × w=3, h=2
-- TimeSeries row: 2 panels × w=6, h=4
-- Tables: w=6 or w=12, h=4–6
-- LogStream: w=12, h=6–8
-
-### Section Layout Pattern
-
-```
-Row 0-1:  [Stat w=3] [Stat w=3] [Stat w=3] [Stat w=3]
-Row 2-5:  [TimeSeries w=6, h=4] [TimeSeries w=6, h=4]
-Row 6-9:  [Table w=6, h=4] [Pie w=6, h=4]
-Row 10+:  [LogStream w=12, h=6]
-```
-
-### Naming Conventions
-- Use question-style titles: "Error rate by route" not "Errors"
-- Prefix with context if multi-service: "[API] Error rate"
-- Include units: "Latency (ms)", "Traffic (req/s)"
+`layout-pack` packs charts row-major into the 12-column grid using per-type defaults (Statistic 3×3, TimeSeries 6×4, Table 6×5, LogStream 12×6, Note 12×2). Override with `id:WxH` when needed. Section blueprints: `reference/layout-recipes.md`. Naming and panel-ordering conventions: `reference/design-playbook.md`.
 
 ---
 
 ## Dashboard Settings
 
 ### Refresh Rate
-Dashboard auto-refreshes at configured interval. Options: 15s, 30s, 1m, 5m, etc.
 
-**⚠️ Query cost warning:** Short refresh (15s) + long time range (90d) = expensive queries running constantly.
-
-Recommendations:
-| Use case | Refresh rate |
-|----------|-------------|
-| Oncall/real-time | 15s–30s |
-| Team health | 1m–5m |
-| Executive/weekly | 5m–15m |
+`dashboard-assemble --refresh oncall|team|exec` (60/300/900s) or pass an explicit integer (≥60). Short refresh + long time range = expensive queries; pick the longer end for exec/weekly boards.
 
 ### Sharing
-All dashboards created via API tokens are shared with everyone in the org (`owner: "X-AXIOM-EVERYONE"`). Private dashboards are not supported with API tokens.
 
-Data visibility is still governed by dataset permissions—users only see data from datasets they can access.
+API tokens create shared dashboards only (`owner: "X-AXIOM-EVERYONE"`); private dashboards aren't supported. Per-user data visibility is still enforced by dataset permissions.
 
 ### URL Time Range Parameters
 
@@ -594,15 +245,7 @@ Data visibility is still governed by dataset permissions—users only see data f
 
 ## Setup
 
-Run `scripts/setup` to check requirements (curl, jq, ~/.axiom.toml).
-
-Config in `~/.axiom.toml` (shared with axiom-sre):
-```toml
-[deployments.prod]
-url = "https://api.axiom.co"
-token = "xaat-your-token"
-org_id = "your-org-id"
-```
+Tools, prerequisites, and `~/.axiom.toml` configuration: see `README.md`. Verify with `scripts/setup`.
 
 ---
 
@@ -612,6 +255,9 @@ org_id = "your-org-id"
 
 | Script | Usage |
 |--------|-------|
+| `scripts/chart-add --type <T> --id <id> --name <n> [--apl <q> \| --mpl <q> --dataset <d>] [--unit <u>]` | **Emit a single chart JSON** to stdout. Splits APL vs MPL; MPL queries are checked for inline time ranges; unit fields applied per chart type. |
+| `scripts/layout-pack <id>:<Type\|WxH> ...` | **Emit a layout JSON array** to stdout. Row-major into a 12-column grid; type names map to default sizes. |
+| `scripts/dashboard-assemble --name … --datasets … --layout F.json [opts] CHART_FILES…` | **Compose a complete dashboard JSON** from chart files + layout. Owns the envelope (`owner`, `schemaVersion`, `qr-` prefix, `refreshTime` validation, id cross-checks). |
 | `scripts/dashboard-list <deploy>` | List all dashboards |
 | `scripts/dashboard-get <deploy> <id>` | Fetch dashboard JSON |
 | `scripts/dashboard-validate <file>` | Validate JSON structure |
@@ -626,9 +272,10 @@ org_id = "your-org-id"
 | `scripts/metrics/datasets <deploy>` | List datasets with `kind` and edge deployment |
 | `scripts/metrics/metrics-spec <deploy> <dataset>` | Fetch MPL query specification |
 | `scripts/metrics/metrics-info <deploy> <dataset> ...` | Discover metrics, tags, and values |
-| `scripts/metrics/metrics-query <deploy> <mpl> <start> <end>` | Execute a metrics query |
+| `scripts/metrics/metrics-query <deploy> <mpl> <start> <end>` | Execute a metrics query (raw — no `$__interval` injection) |
+| `scripts/metrics/mpl-validate-chart <deploy> '<MPL>' [start] [end] [--interval D]` | **Validate a chart MPL pipeline.** Auto-injects `param $__interval: Duration;` and `-p __interval=…`; rejects inline time ranges. Use this in place of raw `metrics-query` when authoring chart queries. |
 
-> **⚠️ Two `axiom-api` scripts exist with different behaviors.** `scripts/axiom-api` rewrites URLs for the dashboard app API (`app.*`). `scripts/metrics/axiom-api` uses raw URLs and supports edge deployment routing. Using the wrong one will produce 404 errors.
+> The two `axiom-api` scripts are not interchangeable. `scripts/axiom-api` is for the dashboard app API; `scripts/metrics/axiom-api` is for data/metrics endpoints and edge routing. Wrong one → 404.
 
 ### Targeted Chart Updates
 
@@ -650,63 +297,29 @@ Use `--version <version>` for optimistic concurrency after fetching the dashboar
 
 ### Workflow
 
-**⚠️ CRITICAL: Always validate queries BEFORE deploying.**
+`chart-add`, `layout-pack`, and `dashboard-assemble` own the JSON shape. Each chart lives in its own temp file; nothing chart-shaped re-enters the agent's context.
 
-**APL workflow:**
-1. Design dashboard (sections + panels)
-2. Write APL for each panel
-3. Build JSON (from template or manually)
-4. **Validate queries** using axiom-sre with explicit time filter
-5. `dashboard-validate` to check structure
-6. `dashboard-create` or `dashboard-update` to deploy
-7. **`dashboard-link` to get URL** — NEVER construct Axiom URLs manually (org IDs and base URLs vary per deployment)
-8. Share link with user
-
-**Metrics/MPL workflow:**
-1. Run `scripts/metrics/metrics-spec` to learn MPL syntax
-2. Run `scripts/metrics/metrics-info` to discover metrics and tags
-3. Design dashboard using the Metrics/MPL Blueprint
-4. Write MPL for each panel
-5. **Validate queries** with `scripts/metrics/metrics-query` using explicit time range
-6. Build JSON: put the full MPL string in `query.apl` AND set `query.metricsDataset` to the dataset name (required — denotes the chart as MPL). Do not set `query.mpl` (rejected by create API).
-7. `dashboard-validate` to check structure
-8. `dashboard-create` or `dashboard-update` to deploy
-9. **`dashboard-link` to get URL**
-10. Share link with user
+1. Discover schema (`axiom-sre` / `getschema` for events; `metrics-spec` + `metrics-info` for metrics).
+2. Write each panel query. Validate APL via `axiom-sre` with an explicit time filter; validate MPL via `scripts/metrics/mpl-validate-chart`.
+3. `chart-add --type … --apl '<APL>'` *or* `chart-add --type … --mpl '<MPL>' --dataset <name>` per chart, redirected to its own file.
+4. `layout-pack <id>:<Type|WxH> …` for the layout (ids in display order).
+5. `dashboard-assemble --name … --datasets … --layout LAYOUT CHART_FILES…` to compose.
+6. `dashboard-validate` then `dashboard-create` (or `dashboard-update`).
+7. `dashboard-link` for the URL — never hand-construct.
 
 ---
 
 ## Sibling Skill Integration
 
-**spl-to-apl:** Translate Splunk SPL → APL. Map `timechart` → TimeSeries, `stats` → Statistic/Table. See `reference/splunk-migration.md`.
-
-**axiom-sre:** Discover schema with `getschema`, explore baselines, identify dimensions, then productize into panels.
-
-**query-metrics:** Discover metrics datasets, metric names, tags, and tag values. Metrics discovery scripts are also vendored locally in `scripts/metrics/`.
+- **spl-to-apl** — Splunk SPL → APL (`timechart` → TimeSeries, `stats` → Statistic/Table). See `reference/splunk-migration.md`.
+- **axiom-sre** — schema discovery via `getschema`, baseline exploration.
+- **query-metrics** — metrics dataset/tag/value discovery; same scripts vendored under `scripts/metrics/`.
 
 ---
 
 ## Templates
 
-Pre-built templates in `reference/templates/`:
-
-| Template | Use case |
-|----------|----------|
-| `service-overview.json` | Single service oncall dashboard with Heatmap |
-| `service-overview-with-filters.json` | Same with SmartFilter (route/status dropdowns) |
-| `api-health.json` | HTTP API with traffic/errors/latency |
-| `blank.json` | Minimal skeleton |
-
-**Placeholders:** `{{service}}`, `{{dataset}}`
-
-**Usage:**
-```bash
-scripts/dashboard-from-template service-overview "my-service" "my-dataset" ./dashboard.json
-scripts/dashboard-validate ./dashboard.json
-scripts/dashboard-create prod ./dashboard.json
-```
-
-**⚠️ Templates assume field names** (`service`, `status`, `route`, `duration_ms`). Discover your schema first and use `sed` to fix mismatches.
+Compose with `chart-add` + `layout-pack` + `dashboard-assemble`. Pre-built templates remain under `reference/templates/` (`blank.json`, `service-overview.json`, `service-overview-with-filters.json`, `api-health.json`) for legacy use; `dashboard-from-template` instantiates them but assumes specific field names (`service`, `status`, `route`, `duration_ms`) and needs sed-fixing. Prefer composition for new work.
 
 ---
 
@@ -714,31 +327,16 @@ scripts/dashboard-create prod ./dashboard.json
 
 | Problem | Cause | Solution |
 |---------|-------|----------|
-| "unable to find dataset" errors | Dataset name doesn't exist in your org | Check available datasets in Axiom UI |
-| "creating private dashboards" 403 | API tokens can only create shared dashboards | Use `owner: "X-AXIOM-EVERYONE"` (the default) |
-| All panels show errors | Field names don't match your schema | Discover schema first, use sed to fix field names |
-| Dashboard shows no data | Service filter too restrictive | Remove or adjust `where service == 'x'` filters |
-| Queries time out | Missing time filter or too broad | Dashboard inherits time from picker; ad-hoc queries need explicit time filter |
-| Wrong org in dashboard URL | Manually constructed URL | **Always use `dashboard-link <deploy> <id>`** — never guess org IDs or base URLs |
-| `getschema` returns 0 rows | Dataset is `otel:metrics:v1`, not events | Run `scripts/metrics/datasets <deploy>` to check kind; use `scripts/metrics/metrics-info` for metrics discovery |
-| Metrics discovery returns empty | Sparse metrics (sensors, batch, cron) outside default 24h window | Retry with `--start` set to 7 days ago; some metrics only report intermittently |
-| 404 from metrics API calls | Used `scripts/axiom-api` (dashboard) instead of `scripts/metrics/axiom-api` (data) | Use `scripts/metrics/axiom-api` for all `/v1/query/`, `/v1/datasets` paths |
-| `find-metrics` returns unexpected results | It searches tag values, not metric names | Use `metrics-info <deploy> <dataset> metrics` to list metric names; `find-metrics` finds metrics associated with a known tag value |
-| Metrics chart renders blank or wrong values | Missing `query.metricsDataset` — backend treats `apl` as APL, not MPL | Set `query.metricsDataset` to the dataset name alongside `query.apl` |
-| `query.mpl` rejected on create | GET may return `query.mpl` for existing metrics charts, but create expects `query.apl` | Move/copy the MPL string into `query.apl` before deploy |
-| `decimals` rejected on create | Create API does not accept chart-level `decimals` even though GET may return it | Omit `decimals` from create payloads |
-| Statistic for an availability/error rate shows `1` instead of `100%` | OTel ratios are 0–1 fractions; `Percent` enum does NOT auto-multiply | `\| map * 100` in MPL, then set `unit: "Percent100"` + `customUnits: "%"`. See [metrics-mpl.md § Percentages and ratios](./reference/metrics-mpl.md#percentages-and-ratios-otel-01-fractions). |
-| Statistic Percent100 renders bare `99.5` instead of `99.5%` | `Percent100` scales the value but does not paint the suffix | Add `customUnits: "%"` alongside `unit: "Percent100"`. |
-| `Unrecognized key: "unit"` on create | Sent the `unit` enum on a non-Statistic chart — TimeSeries, Heatmap, Pie, Table, and LogStream all reject it | Move the suffix to `customUnits` on that chart and encode the unit in the chart `name` (e.g. `"P95 Latency (ms)"`). **Don't react by stripping `unit` from Statistic charts too** — Statistic *needs* both fields. See [Required Chart Unit Configuration](#required-chart-unit-configuration). |
-| `AST Error (Time is provided both in the query and as a parameter)` on a chart | Inline `[…]` time range in the MPL conflicts with the dashboard runtime's API-supplied `start`/`end`. There is no chart-level escape hatch — `overrideDashboardTimeRange` is not a real API field (silently dropped on data charts, rejected on `Note`). | Remove the inline range. Dashboards always inherit time from the picker; use `$__interval` for bucketing and let `timeWindowStart`/`timeWindowEnd` (or the user's picker) control the window. |
-| `Unrecognized keys: "overrideDashboardCompareAgainst", "overrideDashboardTimeRange"` at `[charts N]` on create | A `Note` or `SmartFilter` chart at index N includes one or both of these keys. Data-display chart kinds silently drop them; `Note` and `SmartFilter` reject them. (`SmartFilter` is commonly chart 0 on dashboards with a filter bar, so this often surfaces as `[charts 0]`.) | Strip both keys from every `Note` and `SmartFilter` chart. Best practice: strip from every chart — they have no API effect anywhere. Per-panel time override is UI-only. |
-| `The param $__interval is not defined` from `metrics-query` | The chart query uses `$__interval` but `metrics-query` does not auto-inject the `param` declaration or value the way the dashboard runtime does. | Prepend `param $__interval: Duration;` to the query passed to `metrics-query` and add `-p __interval=5m`. Do NOT rewrite the chart `apl` itself to a fixed duration. |
-| Translated Grafana panel filters or groups on a different subset than the original | Read `expr` but ignored `description` (or vice versa) — both fields carry parts of the panel's spec | Project the canonical panel spec (all five fields together) before authoring MPL. See [reference/grafana-migration.md](./reference/grafana-migration.md). |
-| Metric name from PromQL `expr` not found in the dataset | Hand-rolled guesses instead of applying Prometheus → OTel metric-name rename rules first | Apply rename rules deterministically (drop `_total`, decompose histograms, handle unit suffixes), then validate with `scripts/metrics/metrics-info`. **Label names are not deterministic** — resolve them via reverse-tag discovery, not assumed renaming. See [reference/grafana-migration.md § Name Mapping](./reference/grafana-migration.md#name-mapping-promql--otel-ingest). |
-| Translated MPL chart aggregates across a dimension the PromQL filtered or grouped on | Selector or `by(...)` dimension dropped during PromQL→MPL translation — often because the metric "feels" scoped to the right thing | Every PromQL `{label=…}` becomes a `where`; every `by(…)` dimension becomes a `group by` dimension. See [reference/promql-to-mpl.md](./reference/promql-to-mpl.md). |
-| Panel shipped a different quantity than the one asked for | Author hit a blocker (parser, missing tag, missing metric) and substituted a related quantity instead of deferring — even with a "Y replaces X" disclaimer | If the requested quantity X can't be computed, replace the panel with a `Note` documenting the blocker. Never substitute Y and disclaim it; the disclaimer doesn't propagate to whoever acts on the number. See [Required: Compute What's Asked, or Defer With a Blocker](#required-compute-whats-asked-or-defer-with-a-blocker). |
-| Note panel rejected with `Unrecognized key: "options"` (or `expected string, received undefined` at `[charts N text]`) | Wrapped the Markdown content in `options: { text: ... }`, likely carried over from Grafana text panels (`options.content`) or generalized from Axiom's nested chart options (`tableSettings`, `aggChartOpts`) | `text` is a top-level chart field on Note, never nested. Send `{"type": "Note", "text": "…"}` directly. The `options` key is rejected on every chart kind, not just Note. See [Note](#note) and [reference/chart-config.md § Fields Rejected on Create](./reference/chart-config.md#fields-rejected-on-create-cross-chart). |
-| OTel histogram chart shows nonsense values (`align to … using avg` on a histogram metric) | Histogram translated as a scalar — `histogram_quantile(...)` was not mapped to `bucket … using interpolate_*_histogram` | Read the metric `type` from `metrics-info … metrics <m> info`; use `interpolate_cumulative_histogram` (cumulative) or `interpolate_delta_histogram` (delta) based on the metric's temporality. See [reference/promql-to-mpl.md § Histogram translation](./reference/promql-to-mpl.md#histogram-translation-histogram_quantile--bucket--using-interpolate__histogram). |
+| `getschema` returns 0 rows | Dataset is `otel:metrics:v1` | Use `scripts/metrics/metrics-info` for metrics discovery. |
+| Metrics discovery returns empty | Sparse metrics outside the 24h default window | Retry with `--start` 7 days ago. |
+| 404 from metrics API calls | Used `scripts/axiom-api` (dashboard) instead of `scripts/metrics/axiom-api` | Use `scripts/metrics/axiom-api` for `/v1/query/*`, `/v1/datasets`. |
+| Statistic shows `1` instead of `100%` for a 0–1 ratio | `Percent` enum doesn't auto-multiply | `\| map * 100` in MPL, then `chart-add --unit "%"`. |
+| OTel histogram chart shows nonsense | Histogram aligned as a scalar | Use `bucket … using interpolate_cumulative_histogram` (or `_delta` per `temporality`). See [promql-to-mpl.md § Histogram translation](./reference/promql-to-mpl.md#histogram-translation-histogram_quantile--bucket--using-interpolate__histogram). |
+| Grafana migration filters/groups on the wrong subset | Read `expr` without `description`, or vice versa | Project all five panel fields before authoring; see [reference/grafana-migration.md](./reference/grafana-migration.md). |
+| PromQL metric name not found | Skipped OTel rename rules | Drop `_total`, decompose histograms, normalise units; validate with `metrics-info`. Labels need reverse-tag discovery. See [grafana-migration.md § Name Mapping](./reference/grafana-migration.md#name-mapping-promql--otel-ingest). |
+| MPL chart aggregates across a dimension PromQL filtered/grouped on | Dropped a selector or `by(...)` during translation | Every `{label=…}` → `where`; every `by(…)` → `group by`. See [reference/promql-to-mpl.md](./reference/promql-to-mpl.md). |
+| Panel shipped a different quantity than asked | Substituted instead of deferring | Replace with a `Note` documenting the blocker. See [Compute or Defer](#compute-or-defer). |
+| 403 "creating private dashboards" | API tokens only create shared dashboards | Leave `owner` as `dashboard-assemble`'s default (`X-AXIOM-EVERYONE`). |
 
 ---
 

--- a/skills/building-dashboards/SKILL.md
+++ b/skills/building-dashboards/SKILL.md
@@ -123,7 +123,27 @@ Raw events that answer "what exactly happened?"
 >
 > **No `param` declaration needed in the chart `query.apl`** — the dashboard runtime injects `param $__interval: Duration;` automatically. (The Grafana datasource does the same via a preamble; the Axiom-native dashboard runtime behaves identically.)
 >
-> **Exceptions:** If you are pre-validating a query through `scripts/metrics/metrics-query` (which has no dashboard runtime), substitute a concrete duration for the test call only — do NOT commit that to the chart JSON. For genuinely sparse metrics where `$__interval` would round to an empty bucket (sensors, batch jobs, crons), a fixed wider window (e.g. `1h`) is acceptable; document why in the chart description.
+> **🚫 NEVER use inline time ranges in dashboard chart queries.** The dashboard runtime always supplies `start`/`end` over the API on every query. An inline `[1h..]`, `[30d..]`, etc. in the MPL collides with the API range and the backend rejects the query with `AST Error (Time is provided both in the query and as a parameter)`. The dashboard time picker is the user's UI for time control — let it do its job. `overrideDashboardTimeRange: true` does NOT exempt a metrics chart from this rule; the runtime still passes a range.
+>
+> ```mpl
+> `dataset`:metric | align to $__interval using avg          ✅ dashboard panels
+> `dataset`:metric[30d..] | align to 30d using avg          ❌ inline range — AST time conflict
+> ```
+>
+> **Pre-validating chart queries with `scripts/metrics/metrics-query`:** the dashboard runtime auto-declares `param $__interval: Duration;` AND supplies its value via the request body. `metrics-query` does NOT auto-inject either. To simulate the runtime exactly, prepend `param $__interval: Duration;` to the test query and pass `-p __interval=5m` (or any concrete duration the dashboard would pick) on the command line. Do NOT rewrite the chart's `apl` to a fixed duration just to make the test pass — that hides whether the deployed chart will work.
+>
+> ```bash
+> # ✅ correct — keep $__interval, simulate the runtime injection
+> scripts/metrics/metrics-query -p __interval=5m <deploy> \
+>   'param $__interval: Duration;
+> `dataset`:metric | align to $__interval using avg' now-1h now
+>
+> # ❌ wrong — silently rewriting to `5m` only proves the fixed-duration form works
+> scripts/metrics/metrics-query <deploy> \
+>   '`dataset`:metric | align to 5m using avg' now-1h now
+> ```
+>
+> **Exceptions:** for genuinely sparse metrics where `$__interval` would round to an empty bucket (sensors, batch jobs, crons), a fixed wider window (e.g. `1h`) is acceptable in the committed chart JSON; document why in the chart description.
 
 #### 1. At-a-Glance (Statistic panels)
 Current values for key metrics — answer "what's the state right now?"
@@ -642,6 +662,8 @@ scripts/dashboard-create prod ./dashboard.json
 | `decimals` rejected on create | Create API does not accept chart-level `decimals` even though GET may return it | Omit `decimals` from create payloads |
 | Statistic for an availability/error rate shows `1` instead of `100%` | OTel ratios are 0–1 fractions; `Percent` enum does NOT auto-multiply | `\| map * 100` in MPL, then set `unit: "Percent100"` + `customUnits: "%"`. See [metrics-mpl.md § Percentages and ratios](./reference/metrics-mpl.md#percentages-and-ratios-otel-01-fractions). |
 | Statistic Percent100 renders bare `99.5` instead of `99.5%` | `Percent100` scales the value but does not paint the suffix | Add `customUnits: "%"` alongside `unit: "Percent100"`. |
+| `AST Error (Time is provided both in the query and as a parameter)` on a chart | Inline `[…]` time range in the MPL conflicts with the dashboard runtime's API-supplied `start`/`end`. `overrideDashboardTimeRange: true` does NOT suppress the API range for metrics charts. | Remove the inline range. Dashboards always inherit time from the picker; use `$__interval` for bucketing and let `timeWindowStart`/`timeWindowEnd` (or the user's picker) control the window. |
+| `The param $__interval is not defined` from `metrics-query` | The chart query uses `$__interval` but `metrics-query` does not auto-inject the `param` declaration or value the way the dashboard runtime does. | Prepend `param $__interval: Duration;` to the query passed to `metrics-query` and add `-p __interval=5m`. Do NOT rewrite the chart `apl` itself to a fixed duration. |
 
 ---
 

--- a/skills/building-dashboards/SKILL.md
+++ b/skills/building-dashboards/SKILL.md
@@ -121,7 +121,7 @@ Raw events that answer "what exactly happened?"
 > | align to 1m using avg            ❌ fixed window — wrong granularity at most time ranges
 > ```
 >
-> **No `param` declaration needed in the chart `query.apl`** — the dashboard runtime injects `param $__interval: Duration;` automatically. (The Grafana datasource does the same via a preamble; the Axiom-native dashboard runtime behaves identically — verified against working production dashboards.)
+> **No `param` declaration needed in the chart `query.apl`** — the dashboard runtime injects `param $__interval: Duration;` automatically. (The Grafana datasource does the same via a preamble; the Axiom-native dashboard runtime behaves identically.)
 >
 > **Exceptions:** If you are pre-validating a query through `scripts/metrics/metrics-query` (which has no dashboard runtime), substitute a concrete duration for the test call only — do NOT commit that to the chart JSON. For genuinely sparse metrics where `$__interval` would round to an empty bucket (sensors, batch jobs, crons), a fixed wider window (e.g. `1h`) is acceptable; document why in the chart description.
 
@@ -129,12 +129,15 @@ Raw events that answer "what exactly happened?"
 Current values for key metrics — answer "what's the state right now?"
 - Latest value of primary metrics (e.g., current temperature, power draw)
 - Use `group using avg` or `group using last` depending on metric type (gauge vs counter)
+- **Set the chart unit from metric metadata.** Run `scripts/metrics/metrics-info <deploy> <dataset> metrics <metric> info` to read the metric's `unit`, then pipe it through `scripts/metrics/unit-for` to get the right `unit`/`customUnits` block to splice into the chart. See [reference/metrics-mpl.md § Unit Handling](./reference/metrics-mpl.md#unit-handling).
+- **Percentages from OTel/Prometheus ratios (0–1 fractions): multiply by 100 in MPL AND set both `unit: "Percent100"` and `customUnits: "%"`.** A `compute … using /` ratio or any 0–1 fraction must end with `| map * 100` before `| align`. On the Statistic chart, set BOTH `"unit": "Percent100"` (scales the value) AND `"customUnits": "%"` (paints the `%` suffix); `Percent100` alone renders bare `99.5`. The `Percent` enum does NOT auto-scale 0–1 → 0–100 (`1.0` renders as bare `1`), so don't use it for OTel ratios. See [reference/metrics-mpl.md § Percentages and ratios](./reference/metrics-mpl.md#percentages-and-ratios-otel-01-fractions).
 
 #### 2. Trends (TimeSeries panels)
 Metric trends over time — answer "what changed?"
 - Primary metrics over time, grouped by key dimension
 - Use `align to $__interval using avg|sum|last` for proper time bucketing — `$__interval` is supplied by the dashboard runtime
 - Group by low-cardinality tags only (≤10 series per chart)
+- **TimeSeries (and Heatmap/Pie/Table/LogStream) accept `customUnits` at the API level but the `unit` enum is rejected.** Always also encode the unit in the chart `name` (e.g. `"P95 Latency (ms)"`, `"Memory (MB)"`) so the header is self-describing. For magnitude conversion, scale in MPL (`| map / 1048576` for bytes → MB). See [reference/chart-config.md § Unit Configuration](./reference/chart-config.md#unit-configuration-cross-chart).
 
 #### 3. Breakdowns (TimeSeries or Table panels)
 Per-entity detail — answer "where should I look?"
@@ -638,6 +641,8 @@ scripts/dashboard-create prod ./dashboard.json
 | Metrics chart renders blank or wrong values | Missing `query.metricsDataset` — backend treats `apl` as APL, not MPL | Set `query.metricsDataset` to the dataset name alongside `query.apl` |
 | `query.mpl` rejected on create | GET may return `query.mpl` for existing metrics charts, but create expects `query.apl` | Move/copy the MPL string into `query.apl` before deploy |
 | `decimals` rejected on create | Create API does not accept chart-level `decimals` even though GET may return it | Omit `decimals` from create payloads |
+| Statistic panel for an availability/error rate shows `1` instead of `100%` (or `0.05` instead of `5%`) | OTel ratios are 0–1 fractions; the Axiom `Percent` enum does NOT auto-multiply by 100 | Multiply in MPL with `\| map * 100` before `\| align`, and set BOTH `"unit": "Percent100"` and `"customUnits": "%"` on the chart. See [reference/metrics-mpl.md § Percentages and ratios](./reference/metrics-mpl.md#percentages-and-ratios-otel-01-fractions). |
+| Statistic Percent100 panel renders bare `99.5` instead of `99.5%` | `unit: "Percent100"` scales the value to 0–100 but does NOT paint the `%` suffix | Add `"customUnits": "%"` alongside the existing `"unit": "Percent100"`. |
 
 ---
 

--- a/skills/building-dashboards/reference/chart-config.md
+++ b/skills/building-dashboards/reference/chart-config.md
@@ -42,6 +42,55 @@ Metrics charts require both `query.apl` (the MPL pipeline string) and `query.met
 
 For full contract details, see `reference/metrics-mpl.md`.
 
+## Unit Configuration (Cross-Chart)
+
+Unit-related fields by chart type:
+
+| Chart type | `unit` (enum) | `customUnits` (suffix) | Notes |
+|---|:---:|:---:|---|
+| `Statistic` | ✅ accepted | ✅ accepted | **Both fields are required to render a suffix.** `unit` controls value scaling/formatting (e.g. `Percent100` scales 0–100, `Byte` abbreviates to GB/MB). `customUnits` is what actually paints the suffix string (`%`, `ms`, `req/s`, …). Setting `unit` alone does not append the suffix. |
+| `TimeSeries` | ❌ rejected on create (`Unrecognized key: "unit"`) | ✅ accepted by API, round-trips | **Always also encode the unit in the chart `name`** (e.g. `"P95 Latency (ms)"`) so the header is self-describing. |
+| `Heatmap` | ❌ rejected | ✅ accepted | Same guidance as TimeSeries — encode the unit in `name`. |
+| `Pie` | ❌ rejected | ✅ accepted | Same guidance — encode the unit in `name`. |
+| `Table` | ❌ rejected | ✅ accepted | Same guidance — encode the unit in `name`. |
+| `LogStream` | ❌ rejected | ✅ accepted | Same guidance — encode the unit in `name`. |
+| `Note` | n/a | n/a | n/a (Markdown panel, no values). |
+
+### Statistic: the `unit` + `customUnits` pairing
+
+> **⚠️** A Statistic chart with `unit: "Percent100"` and **no `customUnits`** renders the value as bare `99.5` — the `%` sign is missing. To get `99.5%` you must set **both** `unit: "Percent100"` and `customUnits: "%"`.
+
+The two fields play different roles and you generally want both:
+
+- **`unit` (enum)** — picks a value formatter. `Percent100` interprets the input as already-scaled 0–100. `Byte` abbreviates `1234567` to `1.2 MB`. `TimeMS` abbreviates `90123` to `1.5 min`. With no `unit` set, values render as raw numbers.
+- **`customUnits` (string)** — the literal suffix appended to the formatted value. With `unit: "Byte"` the formatter already says `1.2 MB`, so leave `customUnits` empty unless you want a trailing label like `1.2 MB / pod`. With `unit: "Percent100"`, set `customUnits: "%"` to get the percent sign.
+
+Canonical pattern for an availability/error-rate Statistic backed by an OTel ratio metric:
+
+```mpl
+( … success_rate, … total_rate )
+| compute availability using /
+| map * 100                          // 0–1 fraction → 0–100
+| align to $__interval using avg
+```
+
+```json
+{
+  "type": "Statistic",
+  "unit": "Percent100",
+  "customUnits": "%",
+  "query": { "…": "…" }
+}
+```
+
+### TimeSeries / Heatmap / Pie / Table / LogStream: only `customUnits`
+
+These chart types reject the `unit` enum on the create/update API (`Unrecognized key: "unit"`). They accept `customUnits` and the field round-trips through GET. Recommended approach:
+
+- Set `customUnits` if you want a suffix — it does no harm and persists through the API.
+- **Always also include the unit in the chart `name`**, e.g. `"Memory (MB)"`, `"P95 Latency (s)"`. The header label is the most reliable mechanism for non-Statistic charts.
+- For magnitude conversion, scale in the MPL pipeline (`| map / 1048576` for bytes → MB, `| map * 100` for 0–1 ratio → percent) since `customUnits` is purely a label, not a formatter.
+
 ## Statistic Options
 
 ```json
@@ -65,8 +114,8 @@ For full contract details, see `reference/metrics-mpl.md`.
 | Option | Values | Description |
 |--------|--------|-------------|
 | `colorScheme` | Blue, Orange, Red, Purple, Teal, Yellow, Green, Pink, Grey, Brown | Color theme |
-| `customUnits` | string | Unit suffix (e.g., "ms", "req/s") |
-| `unit` | Auto, Abbreviated, Byte, KB, MB, GB, TimeMS, TimeSec, Percent, etc. | Value formatting |
+| `customUnits` | string | Free-form unit suffix (e.g., "ms", "req/s"). Used verbatim — no smart abbreviation. |
+| `unit` | Auto, Abbreviated, Byte, KB, MB, GB, TimeMS, TimeSec, Percent, etc. | Value formatting (Statistic only — rejected on other chart types) |
 | `decimals` | number | Decimal places in readback/GET payloads; omit on create because the API rejects it |
 | `showChart` | boolean | Show sparkline |
 | `hideValue` | boolean | Hide the main value |
@@ -82,13 +131,43 @@ For full contract details, see `reference/metrics-mpl.md`.
 - **Data**: `Byte`, `Kilobyte`, `Megabyte`, `Gigabyte`
 - **Data rates**: `BitsSec`, `BytesSec`, `KilobitsSec`, `KilobytesSec`, `MegabitsSec`, `MegabytesSec`, `GigabitsSec`, `GigabytesSec`
 - **Time**: `TimeNS`, `TimeUS`, `TimeMS`, `TimeSec`, `TimeMin`, `TimeHour`, `TimeDay`
-- **Percent**: `Percent` (0-1), `Percent100` (0-100)
+- **Percent**: `Percent100` (input is a percentage, 0–100). **Use this for percentage stats and pair with `customUnits: "%"` to actually display the percent sign — see the warning below.**
+
+> **⚠️ Percent vs Percent100, and the `customUnits` pairing requirement.**
+>
+> 1. OTel and Prometheus emit ratios as fractions in `0.0–1.0` (e.g. availability of `1.0` = 100%). The Axiom `Percent` enum does **not** auto-multiply by 100 — `1.0` renders as bare `1`, not `100%`. Always convert to 0–100 in MPL and use `Percent100`:
+>
+>    ```mpl
+>    ( … success_rate, … total_rate ) | compute availability using /
+>    | map * 100
+>    | align to $__interval using avg
+>    ```
+>
+> 2. **`Percent100` alone does not render the `%` suffix.** A Statistic with `unit: "Percent100"` and no `customUnits` shows `99.5`, not `99.5%`. To get the percent sign you must also set `customUnits: "%"`:
+>
+>    ```json
+>    { "type": "Statistic", "unit": "Percent100", "customUnits": "%", "query": {"…":"…"} }
+>    ```
+>
+>    The same pairing logic applies to other `unit` enums when you want a custom suffix appended to the formatted value (e.g. `unit: "Byte", customUnits: "/ pod"` → `1.2 MB / pod`).
 - **Currency**: `CurrencyUSD`, `CurrencyEUR`, `CurrencyGBP`, `CurrencyCAD`, `CurrencyAUD`, `CurrencyJPY`, `CurrencyINR`, `CurrencyCZK`, `CurrencyPLN`
 - **Date**: `DateDateTime`, `DateFromNow`, `DateYYYYMMDDHHmmss`
 
+> **For metrics-backed Statistic charts:** prefer running `scripts/metrics/unit-for <unit>` to map the metric's UCUM/OTel unit (from `metrics-info … metrics <m> info`) to the right enum, falling back to `customUnits` automatically when the unit isn't representable as an enum. See [metrics-mpl.md § Unit Handling](./metrics-mpl.md#unit-handling).
+
 ## TimeSeries Options
 
-TimeSeries chart options are stored in `query.queryOptions.aggChartOpts` as a JSON string.
+TimeSeries supports `customUnits` (free-form suffix) at the chart top level — see the [Unit Configuration](#unit-configuration-cross-chart) table above. The `unit` enum is **not** accepted (`Unrecognized key: "unit"`).
+
+```json
+{
+  "type": "TimeSeries",
+  "customUnits": "req/s",
+  "query": { "apl": "…" }
+}
+```
+
+Other TimeSeries chart options are stored in `query.queryOptions.aggChartOpts` as a JSON string.
 
 ### Key Formats
 
@@ -209,9 +288,12 @@ Controls what the TimeSeries panel displays. Set in `query.queryOptions.timeSeri
 ```json
 {
   "type": "Pie",
+  "customUnits": "evt",
   "hideHeader": false
 }
 ```
+
+Pie accepts `customUnits` (suffix, no abbreviation). The `unit` enum is rejected — see the [Unit Configuration](#unit-configuration-cross-chart) table.
 
 ## Note Options
 
@@ -227,11 +309,12 @@ Note content supports GitHub Flavored Markdown.
 
 ## Heatmap Options
 
-Heatmap charts use the default options. Color scheme is fixed to blue gradient.
+Heatmap charts use the default options. Color scheme is fixed to blue gradient. Heatmap accepts `customUnits` (the `unit` enum is rejected — see the [Unit Configuration](#unit-configuration-cross-chart) table).
 
 ```json
 {
   "type": "Heatmap",
+  "customUnits": "ms",
   "query": {
     "apl": "['logs'] | summarize histogram(duration_ms, 15) by bin_auto(_time)"
   }

--- a/skills/building-dashboards/reference/chart-config.md
+++ b/skills/building-dashboards/reference/chart-config.md
@@ -131,29 +131,11 @@ These chart types reject the `unit` enum on the create/update API (`Unrecognized
 - **Data**: `Byte`, `Kilobyte`, `Megabyte`, `Gigabyte`
 - **Data rates**: `BitsSec`, `BytesSec`, `KilobitsSec`, `KilobytesSec`, `MegabitsSec`, `MegabytesSec`, `GigabitsSec`, `GigabytesSec`
 - **Time**: `TimeNS`, `TimeUS`, `TimeMS`, `TimeSec`, `TimeMin`, `TimeHour`, `TimeDay`
-- **Percent**: `Percent100` (input is a percentage, 0–100). **Use this for percentage stats and pair with `customUnits: "%"` to actually display the percent sign — see the warning below.**
-
-> **⚠️ Percent vs Percent100, and the `customUnits` pairing requirement.**
->
-> 1. OTel and Prometheus emit ratios as fractions in `0.0–1.0` (e.g. availability of `1.0` = 100%). The Axiom `Percent` enum does **not** auto-multiply by 100 — `1.0` renders as bare `1`, not `100%`. Always convert to 0–100 in MPL and use `Percent100`:
->
->    ```mpl
->    ( … success_rate, … total_rate ) | compute availability using /
->    | map * 100
->    | align to $__interval using avg
->    ```
->
-> 2. **`Percent100` alone does not render the `%` suffix.** A Statistic with `unit: "Percent100"` and no `customUnits` shows `99.5`, not `99.5%`. To get the percent sign you must also set `customUnits: "%"`:
->
->    ```json
->    { "type": "Statistic", "unit": "Percent100", "customUnits": "%", "query": {"…":"…"} }
->    ```
->
->    The same pairing logic applies to other `unit` enums when you want a custom suffix appended to the formatted value (e.g. `unit: "Byte", customUnits: "/ pod"` → `1.2 MB / pod`).
+- **Percent**: `Percent100` (input is a percentage, 0–100). Pair with `customUnits: "%"` to display the percent sign — see [Unit Configuration](#unit-configuration-cross-chart). The `Percent` enum does NOT auto-multiply 0–1 fractions; convert OTel ratios to 0–100 in MPL.
 - **Currency**: `CurrencyUSD`, `CurrencyEUR`, `CurrencyGBP`, `CurrencyCAD`, `CurrencyAUD`, `CurrencyJPY`, `CurrencyINR`, `CurrencyCZK`, `CurrencyPLN`
 - **Date**: `DateDateTime`, `DateFromNow`, `DateYYYYMMDDHHmmss`
 
-> **For metrics-backed Statistic charts:** prefer running `scripts/metrics/unit-for <unit>` to map the metric's UCUM/OTel unit (from `metrics-info … metrics <m> info`) to the right enum, falling back to `customUnits` automatically when the unit isn't representable as an enum. See [metrics-mpl.md § Unit Handling](./metrics-mpl.md#unit-handling).
+> **For metrics-backed Statistic charts:** run `scripts/metrics/unit-for <unit>` to map the metric's UCUM/OTel unit (from `metrics-info … metrics <m> info`) to the right enum, falling back to `customUnits` automatically when the unit isn't representable as an enum. See [metrics-mpl.md § Unit Handling](./metrics-mpl.md#unit-handling).
 
 ## TimeSeries Options
 

--- a/skills/building-dashboards/reference/chart-config.md
+++ b/skills/building-dashboards/reference/chart-config.md
@@ -1,200 +1,34 @@
-# Chart Configuration Options
+# Chart Configuration — Advanced Options
 
-Charts support JSON configuration options beyond the query. These are set at the chart level.
+`scripts/chart-add` covers the common fields per chart kind (id, name, query, dataset, unit, sparkline, Note text). It also enforces the type-aware unit rules and never emits the deny-listed fields below — so when authoring through `chart-add` none of this reference is needed.
 
-## Common Options (All Charts)
+This file documents the options `chart-add` does **not** expose. Reach for it when you need to merge advanced fields with `jq` after `chart-add` emits the base chart, or when extending `chart-add` itself.
 
-```json
-{
-  "hideHeader": false
-}
-```
+## TimeSeries — `query.queryOptions`
 
-> **Do not send `overrideDashboardTimeRange` or `overrideDashboardCompareAgainst`.** They are frontend-only fields. The create/update API silently drops them on data charts (Statistic, TimeSeries, Pie, Table, LogStream, Heatmap) — they never round-trip on GET, so they have no effect — and **rejects them outright on `Note` and `SmartFilter` charts** with `Unrecognized keys: "overrideDashboardCompareAgainst", "overrideDashboardTimeRange"` at `[charts <index>]`. They are also rejected at the dashboard top level (`unknown field`). Per-panel time override is UI-only; there is no API representation today. Verified empirically against `dev`, `staging`, and `axiom` on 2026-05-09.
+`chart-add` doesn't write `query.queryOptions`. Merge it in with `jq` for non-default rendering.
 
-## Metrics/MPL Query (MetricsDB Charts)
+### `aggChartOpts` (per-series rendering)
 
-Metrics charts require both `query.apl` (the MPL pipeline string) and `query.metricsDataset` (the dataset name, e.g. `"otel-metrics"`). The `metricsDataset` field is what flags the chart as MPL; without it the backend treats `apl` as APL and the chart misbehaves. Do not send `query.mpl` — the create API rejects it. Run `scripts/metrics/metrics-spec` to learn the full syntax before composing queries.
+JSON-encoded string keyed by query column. Per-series options:
 
-### Minimal Metrics Query
+| Option | Values | Effect |
+|--------|--------|--------|
+| `variant` | `line` (default), `area`, `bars` | Render mode |
+| `scaleDistr` | `linear` (default), `log` | Y-axis scale |
+| `displayNull` | `auto`, `null` (gaps), `span` (join), `zero` (fill) | Missing-data handling |
 
-```json
-{
-  "type": "TimeSeries",
-  "query": {
-    "apl": "`otel-metrics`:`system.cpu.utilization`",
-    "metricsDataset": "otel-metrics"
-  }
-}
-```
+**Deriving the column key** — `aggChartOpts` is keyed by a JSON-stringified column descriptor:
 
-### Metrics Query with Filters and Transformations
-
-```json
-{
-  "type": "TimeSeries",
-  "query": {
-    "apl": "`otel-metrics`:`http.server.duration`\n| where `service.name` == \"api\"\n| where `deployment.environment` == \"prod\"\n| align to $__interval using avg\n| group by `service.name` using avg",
-    "metricsDataset": "otel-metrics"
-  }
-}
-```
-
-For full contract details, see `reference/metrics-mpl.md`.
-
-## Unit Configuration (Cross-Chart)
-
-Unit-related fields by chart type:
-
-| Chart type | `unit` (enum) | `customUnits` (suffix) | Notes |
-|---|:---:|:---:|---|
-| `Statistic` | ✅ accepted | ✅ accepted | **Both fields are required to render a suffix.** `unit` controls value scaling/formatting (e.g. `Percent100` scales 0–100, `Byte` abbreviates to GB/MB). `customUnits` is what actually paints the suffix string (`%`, `ms`, `req/s`, …). Setting `unit` alone does not append the suffix. |
-| `TimeSeries` | ❌ rejected on create (`Unrecognized key: "unit"`) | ✅ accepted by API, round-trips | **Always also encode the unit in the chart `name`** (e.g. `"P95 Latency (ms)"`) so the header is self-describing. |
-| `Heatmap` | ❌ rejected | ✅ accepted | Same guidance as TimeSeries — encode the unit in `name`. |
-| `Pie` | ❌ rejected | ✅ accepted | Same guidance — encode the unit in `name`. |
-| `Table` | ❌ rejected | ✅ accepted | Same guidance — encode the unit in `name`. |
-| `LogStream` | ❌ rejected | ✅ accepted | Same guidance — encode the unit in `name`. |
-| `Note` | n/a | n/a | n/a (Markdown panel, no values). |
-
-### Statistic: the `unit` + `customUnits` pairing
-
-> **⚠️** A Statistic chart with `unit: "Percent100"` and **no `customUnits`** renders the value as bare `99.5` — the `%` sign is missing. To get `99.5%` you must set **both** `unit: "Percent100"` and `customUnits: "%"`.
-
-The two fields play different roles and you generally want both:
-
-- **`unit` (enum)** — picks a value formatter. `Percent100` interprets the input as already-scaled 0–100. `Byte` abbreviates `1234567` to `1.2 MB`. `TimeMS` abbreviates `90123` to `1.5 min`. With no `unit` set, values render as raw numbers.
-- **`customUnits` (string)** — the literal suffix appended to the formatted value. With `unit: "Byte"` the formatter already says `1.2 MB`, so leave `customUnits` empty unless you want a trailing label like `1.2 MB / pod`. With `unit: "Percent100"`, set `customUnits: "%"` to get the percent sign.
-
-Canonical pattern for an availability/error-rate Statistic backed by an OTel ratio metric:
-
-```mpl
-( … success_rate, … total_rate )
-| compute availability using /
-| map * 100                          // 0–1 fraction → 0–100
-| align to $__interval using avg
-```
-
-```json
-{
-  "type": "Statistic",
-  "unit": "Percent100",
-  "customUnits": "%",
-  "query": { "…": "…" }
-}
-```
-
-### TimeSeries / Heatmap / Pie / Table / LogStream: only `customUnits`
-
-These chart types reject the `unit` enum on the create/update API (`Unrecognized key: "unit"`). They accept `customUnits` and the field round-trips through GET. Recommended approach:
-
-- Set `customUnits` if you want a suffix — it does no harm and persists through the API.
-- **Always also include the unit in the chart `name`**, e.g. `"Memory (MB)"`, `"P95 Latency (s)"`. The header label is the most reliable mechanism for non-Statistic charts.
-- For magnitude conversion, scale in the MPL pipeline (`| map / 1048576` for bytes → MB, `| map * 100` for 0–1 ratio → percent) since `customUnits` is purely a label, not a formatter.
-
-## Fields Rejected on Create (Cross-Chart)
-
-The create API enforces a closed field list per chart kind. Sending a field outside the accepted set fails fast with HTTP 400 and a uniform error string:
-
-```
-dashboard validation failed at [charts <index>]: Unrecognized key: "<field>"
-```
-
-**Universally rejected** (every chart kind, including `Statistic` and `Note`):
-
-| Field | Notes |
+| Query pattern | Key |
 |---|---|
-| `decimals` | Returned by GET on existing dashboards (UI-created charts may include it), but the create/update API rejects it. Omit from create payloads. |
-| `description` (chart-level) | Chart-level `description` is rejected on every chart kind. The dashboard-level `description` (top-level, sibling of `name` and `owner`) **is** accepted — that's the field templates use. |
-| `aggChartOpts` (chart-level) | Per-series chart options live **inside the query**, at `query.queryOptions.aggChartOpts`, as a JSON-encoded string. Placing `aggChartOpts` at the chart top level fails with `Unrecognized key: "aggChartOpts"` on every chart kind. Only `TimeSeries` consumes the nested form (`Statistic`, `Note`, `SmartFilter`, `Pie`, `Table`, `LogStream`, `Heatmap` have no per-series options). See [TimeSeries Options](#timeseries-options) for the correct shape. |
-| `options` | Rejected on every chart kind. Common contamination from Grafana text panels (`options.content`) or over-generalization from Axiom's *named* nested chart options (`tableSettings`, `aggChartOpts`). Note `text` is a top-level field, not `options.text`. There is no generic `options` bag at the chart level. |
-
-**Per-chart-kind rejections** — see [Unit Configuration (Cross-Chart)](#unit-configuration-cross-chart) for the full matrix:
-
-- `unit` is rejected on `TimeSeries`, `Heatmap`, `Pie`, `Table`, `LogStream`, `Note`. Accepted on `Statistic` only.
-- `customUnits` is rejected on `Note`. Accepted on every other chart kind.
-
-**Asymmetric: silently dropped on data charts, rejected on `Note` and `SmartFilter`** — `overrideDashboardTimeRange` and `overrideDashboardCompareAgainst`. On `Statistic`, `TimeSeries`, `Pie`, `Table`, `LogStream`, and `Heatmap` the create API accepts these keys but does not persist them — they are absent on read-back, so they are no-ops. On `Note` and `SmartFilter` the same payload is rejected with `Unrecognized keys: "overrideDashboardCompareAgainst", "overrideDashboardTimeRange"` at `[charts <index>]`. They are also rejected at the dashboard top level. Treat them as unsupported by the API and never include them. (`SmartFilter` is commonly chart 0 on dashboards that use a filter bar, which is why this error often surfaces as `[charts 0]`.)
-
-Verified empirically against the staging create endpoint (28-cell probe, 2026-05-08) and against `dev`, `staging`, and `axiom` for the override keys (2026-05-09).
-
-## Statistic Options
-
-```json
-{
-  "type": "Statistic",
-  "colorScheme": "Blue",
-  "customUnits": "req/s",
-  "unit": "Auto",
-  "showChart": true,
-  "hideValue": false,
-  "errorThreshold": "Above",
-  "errorThresholdValue": "100",
-  "warningThreshold": "Above",
-  "warningThresholdValue": "50",
-  "invertTheme": false
-}
-```
-
-> **API gotcha:** `decimals` is rejected on create for every chart kind, including `Statistic`. The field round-trips on GET (and UI-created dashboards may include it), but omit it from create payloads. See [Fields Rejected on Create (Cross-Chart)](#fields-rejected-on-create-cross-chart) for the full closed-list rules.
-
-| Option | Values | Description |
-|--------|--------|-------------|
-| `colorScheme` | Blue, Orange, Red, Purple, Teal, Yellow, Green, Pink, Grey, Brown | Color theme |
-| `customUnits` | string | Free-form unit suffix (e.g., "ms", "req/s"). Used verbatim — no smart abbreviation. |
-| `unit` | Auto, Abbreviated, Byte, KB, MB, GB, TimeMS, TimeSec, Percent, etc. | Value formatting (Statistic only — rejected on other chart types) |
-| `decimals` | number | Decimal places in readback/GET payloads; omit on create because the API rejects it |
-| `showChart` | boolean | Show sparkline |
-| `hideValue` | boolean | Hide the main value |
-| `errorThreshold` | Above, AboveOrEqual, Below, BelowOrEqual, AboveOrBelow | Error condition |
-| `errorThresholdValue` | string | Error threshold value |
-| `warningThreshold` | same as error | Warning condition |
-| `warningThresholdValue` | string | Warning threshold value |
-| `invertTheme` | boolean | Invert colors |
-
-### Available Units
-
-- **Numbers**: `Auto`, `Abbreviated`
-- **Data**: `Byte`, `Kilobyte`, `Megabyte`, `Gigabyte`
-- **Data rates**: `BitsSec`, `BytesSec`, `KilobitsSec`, `KilobytesSec`, `MegabitsSec`, `MegabytesSec`, `GigabitsSec`, `GigabytesSec`
-- **Time**: `TimeNS`, `TimeUS`, `TimeMS`, `TimeSec`, `TimeMin`, `TimeHour`, `TimeDay`
-- **Percent**: `Percent100` (input is a percentage, 0–100). Pair with `customUnits: "%"` to display the percent sign — see [Unit Configuration](#unit-configuration-cross-chart). The `Percent` enum does NOT auto-multiply 0–1 fractions; convert OTel ratios to 0–100 in MPL.
-- **Currency**: `CurrencyUSD`, `CurrencyEUR`, `CurrencyGBP`, `CurrencyCAD`, `CurrencyAUD`, `CurrencyJPY`, `CurrencyINR`, `CurrencyCZK`, `CurrencyPLN`
-- **Date**: `DateDateTime`, `DateFromNow`, `DateYYYYMMDDHHmmss`
-
-> **For metrics-backed Statistic charts:** run `scripts/metrics/unit-for <unit>` to map the metric's UCUM/OTel unit (from `metrics-info … metrics <m> info`) to the right enum, falling back to `customUnits` automatically when the unit isn't representable as an enum. See [metrics-mpl.md § Unit Handling](./metrics-mpl.md#unit-handling).
-
-## TimeSeries Options
-
-TimeSeries supports `customUnits` (free-form suffix) at the chart top level — see the [Unit Configuration](#unit-configuration-cross-chart) table above. The `unit` enum is **not** accepted (`Unrecognized key: "unit"`).
-
-```json
-{
-  "type": "TimeSeries",
-  "customUnits": "req/s",
-  "query": { "apl": "…" }
-}
-```
-
-Other TimeSeries chart options are stored in `query.queryOptions.aggChartOpts` as a JSON string.
-
-### Key Formats
-
-**Important:** The `"*"` wildcard is unreliable. Always use the specific key format derived from your query.
-
-#### Deriving the Key
-
-The key format depends on how the column is computed:
-
-| Query Pattern | Key Format |
-|---------------|------------|
 | `summarize count()` | `{"alias":"count_","op":"count"}` |
 | `summarize sum(field)` | `{"alias":"sum_field","op":"sum"}` |
 | `summarize ['Name'] = sum(field) / 1000` | `{"alias":"Name","field":"field","op":"computed"}` |
-| `summarize ['Name'] = round(sum(field), 1)` | `{"alias":"Name","field":"field","op":"computed"}` |
 
-**Rule:** If the column uses any expression (math, `round()`, etc.), use `"op":"computed"` and include the source `"field"`.
+Any expression on the right-hand side (math, `round()`, etc.) makes it `op:"computed"` with the source `field`. Wildcard `"*"` is unreliable — always use the specific key. The `field` value is the bare source name (no brackets, no `properties.` prefix).
 
-#### Simple Aggregation Example
+Simple example:
 
 ```json
 {
@@ -208,56 +42,17 @@ The key format depends on how the column is computed:
 }
 ```
 
-#### Computed Column Example
+### `timeSeriesView`
 
-For `['Ingest GB'] = round(sum(['properties.hourly_ingest_bytes']) / 1e9, 1)`:
+Set in `query.queryOptions.timeSeriesView`:
 
-```json
-{
-  "aggChartOpts": "{\"{\\\"alias\\\":\\\"Ingest GB\\\",\\\"field\\\":\\\"properties.hourly_ingest_bytes\\\",\\\"op\\\":\\\"computed\\\"}\":{\"variant\":\"bars\",\"displayNull\":\"auto\"}}"
-}
-```
+| Value | Effect |
+|---|---|
+| `charts` (default) | Chart only |
+| `resultsTable` | Summary totals only |
+| `charts\|resultsTable` | Chart + totals below |
 
-**Note:** The `field` value is the source field name without brackets or the `properties.` prefix path as written in the query.
-
-### View Mode (timeSeriesView)
-
-Controls what the TimeSeries panel displays. Set in `query.queryOptions.timeSeriesView`.
-
-| Value | Description |
-|-------|-------------|
-| `charts` | Chart only (default) |
-| `resultsTable` | Summary totals table only |
-| `charts\|resultsTable` | Chart with totals table below — shows both the time series and an aggregated summary |
-
-```json
-{
-  "type": "TimeSeries",
-  "query": {
-    "apl": "['logs'] | summarize count() by bin_auto(_time), service",
-    "queryOptions": {
-      "timeSeriesView": "charts|resultsTable"
-    }
-  }
-}
-```
-
-### Per-Series Options (inside aggChartOpts)
-
-| Option | Values | Description |
-|--------|--------|-------------|
-| `variant` | `line`, `area`, `bars` | Chart display mode |
-| `scaleDistr` | `linear`, `log` | Y-axis scale |
-| `displayNull` | `auto`, `null`, `span`, `zero` | Missing data handling |
-
-### displayNull Values
-
-- `auto`: Best representation based on chart type
-- `null`: Skip/ignore missing values (gaps in chart)
-- `span`: Join adjacent values across gaps
-- `zero`: Fill missing with zeros
-
-## LogStream / Table Options
+## LogStream / Table — `tableSettings`
 
 ```json
 {
@@ -280,63 +75,46 @@ Controls what the TimeSeries panel displays. Set in `query.queryOptions.timeSeri
 }
 ```
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `columns` | array | Column order and widths (objects with `name` and `width`) |
-| `fontSize` | string | Font size (e.g., "12px") |
-| `highlightSeverity` | boolean | Color-code by log level |
-| `showRaw` | boolean | Show raw JSON |
-| `showEvent` | boolean | Show event column |
-| `showTimestamp` | boolean | Show timestamp column |
-| `wrapLines` | boolean | Wrap long lines |
-| `hideNulls` | boolean | Hide null values |
+| Field | Effect |
+|---|---|
+| `columns` | Column order and widths (`{name, width}` objects). |
+| `fontSize` | CSS string (e.g. `"12px"`). |
+| `highlightSeverity` | Color rows by log level. |
+| `showRaw` / `showEvent` / `showTimestamp` | Toggle built-in columns. |
+| `wrapLines` | Wrap long lines. |
+| `hideNulls` | Hide null cells. |
 
-## Pie Options
+## Statistic — extra cosmetic options
 
-```json
-{
-  "type": "Pie",
-  "customUnits": "evt",
-  "hideHeader": false
-}
-```
+`chart-add` exposes `--unit` and `--show-chart`. The other Statistic fields:
 
-Pie accepts `customUnits` (suffix, no abbreviation). The `unit` enum is rejected — see the [Unit Configuration](#unit-configuration-cross-chart) table.
+| Field | Values | Effect |
+|---|---|---|
+| `colorScheme` | Blue, Orange, Red, Purple, Teal, Yellow, Green, Pink, Grey, Brown | Color theme. |
+| `hideValue` | bool | Hide the main value (e.g. show only the sparkline). |
+| `invertTheme` | bool | Invert colors. |
+| `errorThreshold` / `warningThreshold` | `Above`, `AboveOrEqual`, `Below`, `BelowOrEqual`, `AboveOrBelow` | Comparison direction. The companion *value* field is not reachable through the create API on probed deployments — see `chart-add` header for the gap; set thresholds via the UI for now. |
 
-## Note Options
+## `unit` enum reference (Statistic only)
 
-```json
-{
-  "type": "Note",
-  "text": "## Section Header\n\nMarkdown content here.",
-  "variant": "default"
-}
-```
+`chart-add --unit` accepts a friendly string and maps via `scripts/metrics/unit-for`. The enum it picks from:
 
-Note content supports GitHub Flavored Markdown.
+- Numbers: `Auto`, `Abbreviated`
+- Data: `Byte`, `Kilobyte`, `Megabyte`, `Gigabyte`
+- Data rates: `BitsSec`, `BytesSec`, `KilobitsSec`/…/`GigabytesSec`
+- Time: `TimeNS`, `TimeUS`, `TimeMS`, `TimeSec`, `TimeMin`, `TimeHour`, `TimeDay`
+- Percent: `Percent100` (input is 0–100; pair with `customUnits: "%"`). The `Percent` enum does NOT auto-multiply — convert OTel 0–1 ratios in MPL.
+- Currency: `CurrencyUSD`, `CurrencyEUR`, `CurrencyGBP`, `CurrencyCAD`, `CurrencyAUD`, `CurrencyJPY`, `CurrencyINR`, `CurrencyCZK`, `CurrencyPLN`
+- Date: `DateDateTime`, `DateFromNow`, `DateYYYYMMDDHHmmss`
 
-## Heatmap Options
-
-Heatmap charts use the default options. Color scheme is fixed to blue gradient. Heatmap accepts `customUnits` (the `unit` enum is rejected — see the [Unit Configuration](#unit-configuration-cross-chart) table).
-
-```json
-{
-  "type": "Heatmap",
-  "customUnits": "ms",
-  "query": {
-    "apl": "['logs'] | summarize histogram(duration_ms, 15) by bin_auto(_time)"
-  }
-}
-```
+`TimeSeries`/`Heatmap`/`Pie`/`Table`/`LogStream` reject the `unit` enum entirely — set `customUnits` and encode the unit in `name` instead.
 
 ## Annotations
 
-Display deployment markers, incidents, or custom events on charts.
-
-Annotations are managed via the Axiom API `/v2/annotations` endpoint:
+Annotations (deployment markers, incidents) are managed via `/v2/annotations`, not via chart JSON:
 
 ```bash
-curl -X 'POST' 'https://api.axiom.co/v2/annotations' \
+curl -X POST 'https://api.axiom.co/v2/annotations' \
   -H 'Authorization: Bearer $AXIOM_TOKEN' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -349,26 +127,37 @@ curl -X 'POST' 'https://api.axiom.co/v2/annotations' \
   }'
 ```
 
-Or use GitHub Actions:
-```yaml
-- name: Add annotation
-  uses: axiomhq/annotation-action@v0.1.0
-  with:
-    axiomToken: ${{ secrets.AXIOM_TOKEN }}
-    datasets: http-logs
-    type: "deploy"
-    title: "Production deployment"
+Or via GitHub Actions: `axiomhq/annotation-action@v0.1.0`.
+
+## Comparison Period
+
+Compare current time range against a historical offset via URL params, not chart JSON: `?t_qr=24h&t_against=-1d` (or `-1W`). No equivalent chart-level field today.
+
+## Per-Panel Time-Range Override
+
+UI-only. `overrideDashboardTimeRange` has no API representation — silently dropped on data charts, rejected on `Note`/`SmartFilter`. Edit per-panel time in the UI (Edit panel → Time range → Custom).
+
+## Fields Rejected on Create
+
+The create API has a closed field list per chart kind. Sending an unknown field returns:
+
+```
+dashboard validation failed at [charts <index>]: Unrecognized key: "<field>"
 ```
 
-## Comparison Period (Against)
+`chart-add` never emits these, so authoring through it can't trigger the error. Useful when debugging a hand-written or migrated payload, or when extending `chart-add`.
 
-Compare current time range against a historical period:
-- `-1D`: Same time yesterday
-- `-1W`: Same time last week
-- Custom offset
+**Universally rejected** (every chart kind):
 
-Use in dashboard URL: `?t_qr=24h&t_against=-1d`
+| Field | Notes |
+|---|---|
+| `decimals` | GET returns it on UI-created charts; create rejects it. |
+| `description` (chart-level) | Rejected on every chart kind. The dashboard-level `description` (top-level, sibling of `name`) **is** accepted. |
+| `aggChartOpts` (chart-level) | Belongs at `query.queryOptions.aggChartOpts`, not at chart top level. Only `TimeSeries` consumes it. |
+| `options` | Rejected on every chart kind. Common contamination from Grafana text panels (`options.content`). Note `text` is top-level, not `options.text`. |
+| `overrideDashboardTimeRange`, `overrideDashboardCompareAgainst` | No API representation. Silently dropped on data charts, rejected on `Note` and `SmartFilter`, rejected at dashboard top level. |
 
-## Custom Time Range per Panel
+**Per-chart rejections:**
 
-Per-panel time-range override is **UI-only**. The dashboard create/update API has no field for it — `overrideDashboardTimeRange` is silently dropped on data charts and rejected on `Note`/`SmartFilter` (see [Fields Rejected on Create](#fields-rejected-on-create-cross-chart)). To diverge a panel from the dashboard picker today, edit it in the UI (Edit panel → Time range → Custom); the JSON payload you POST cannot encode this.
+- `unit` — accepted on `Statistic` only. Rejected on `TimeSeries`, `Heatmap`, `Pie`, `Table`, `LogStream`, `Note`.
+- `customUnits` — rejected on `Note`. Accepted on every other chart kind.

--- a/skills/building-dashboards/reference/chart-config.md
+++ b/skills/building-dashboards/reference/chart-config.md
@@ -6,11 +6,11 @@ Charts support JSON configuration options beyond the query. These are set at the
 
 ```json
 {
-  "overrideDashboardTimeRange": false,
-  "overrideDashboardCompareAgainst": false,
   "hideHeader": false
 }
 ```
+
+> **Do not send `overrideDashboardTimeRange` or `overrideDashboardCompareAgainst`.** They are frontend-only fields. The create/update API silently drops them on data charts (Statistic, TimeSeries, Pie, Table, LogStream, Heatmap) — they never round-trip on GET, so they have no effect — and **rejects them outright on `Note` and `SmartFilter` charts** with `Unrecognized keys: "overrideDashboardCompareAgainst", "overrideDashboardTimeRange"` at `[charts <index>]`. They are also rejected at the dashboard top level (`unknown field`). Per-panel time override is UI-only; there is no API representation today. Verified empirically against `dev`, `staging`, and `axiom` on 2026-05-09.
 
 ## Metrics/MPL Query (MetricsDB Charts)
 
@@ -91,6 +91,32 @@ These chart types reject the `unit` enum on the create/update API (`Unrecognized
 - **Always also include the unit in the chart `name`**, e.g. `"Memory (MB)"`, `"P95 Latency (s)"`. The header label is the most reliable mechanism for non-Statistic charts.
 - For magnitude conversion, scale in the MPL pipeline (`| map / 1048576` for bytes → MB, `| map * 100` for 0–1 ratio → percent) since `customUnits` is purely a label, not a formatter.
 
+## Fields Rejected on Create (Cross-Chart)
+
+The create API enforces a closed field list per chart kind. Sending a field outside the accepted set fails fast with HTTP 400 and a uniform error string:
+
+```
+dashboard validation failed at [charts <index>]: Unrecognized key: "<field>"
+```
+
+**Universally rejected** (every chart kind, including `Statistic` and `Note`):
+
+| Field | Notes |
+|---|---|
+| `decimals` | Returned by GET on existing dashboards (UI-created charts may include it), but the create/update API rejects it. Omit from create payloads. |
+| `description` (chart-level) | Chart-level `description` is rejected on every chart kind. The dashboard-level `description` (top-level, sibling of `name` and `owner`) **is** accepted — that's the field templates use. |
+| `aggChartOpts` (chart-level) | Per-series chart options live **inside the query**, at `query.queryOptions.aggChartOpts`, as a JSON-encoded string. Placing `aggChartOpts` at the chart top level fails with `Unrecognized key: "aggChartOpts"` on every chart kind. Only `TimeSeries` consumes the nested form (`Statistic`, `Note`, `SmartFilter`, `Pie`, `Table`, `LogStream`, `Heatmap` have no per-series options). See [TimeSeries Options](#timeseries-options) for the correct shape. |
+| `options` | Rejected on every chart kind. Common contamination from Grafana text panels (`options.content`) or over-generalization from Axiom's *named* nested chart options (`tableSettings`, `aggChartOpts`). Note `text` is a top-level field, not `options.text`. There is no generic `options` bag at the chart level. |
+
+**Per-chart-kind rejections** — see [Unit Configuration (Cross-Chart)](#unit-configuration-cross-chart) for the full matrix:
+
+- `unit` is rejected on `TimeSeries`, `Heatmap`, `Pie`, `Table`, `LogStream`, `Note`. Accepted on `Statistic` only.
+- `customUnits` is rejected on `Note`. Accepted on every other chart kind.
+
+**Asymmetric: silently dropped on data charts, rejected on `Note` and `SmartFilter`** — `overrideDashboardTimeRange` and `overrideDashboardCompareAgainst`. On `Statistic`, `TimeSeries`, `Pie`, `Table`, `LogStream`, and `Heatmap` the create API accepts these keys but does not persist them — they are absent on read-back, so they are no-ops. On `Note` and `SmartFilter` the same payload is rejected with `Unrecognized keys: "overrideDashboardCompareAgainst", "overrideDashboardTimeRange"` at `[charts <index>]`. They are also rejected at the dashboard top level. Treat them as unsupported by the API and never include them. (`SmartFilter` is commonly chart 0 on dashboards that use a filter bar, which is why this error often surfaces as `[charts 0]`.)
+
+Verified empirically against the staging create endpoint (28-cell probe, 2026-05-08) and against `dev`, `staging`, and `axiom` for the override keys (2026-05-09).
+
 ## Statistic Options
 
 ```json
@@ -109,7 +135,7 @@ These chart types reject the `unit` enum on the create/update API (`Unrecognized
 }
 ```
 
-> **API gotcha:** `decimals` is returned by GET and may appear in existing dashboards, but the create API rejects it. Omit `decimals` from create payloads.
+> **API gotcha:** `decimals` is rejected on create for every chart kind, including `Statistic`. The field round-trips on GET (and UI-created dashboards may include it), but omit it from create payloads. See [Fields Rejected on Create (Cross-Chart)](#fields-rejected-on-create-cross-chart) for the full closed-list rules.
 
 | Option | Values | Description |
 |--------|--------|-------------|
@@ -345,6 +371,4 @@ Use in dashboard URL: `?t_qr=24h&t_against=-1d`
 
 ## Custom Time Range per Panel
 
-Individual panels can override the dashboard time range:
-- Set `overrideDashboardTimeRange: true` in chart config
-- Via UI: Edit panel → Time range → Custom
+Per-panel time-range override is **UI-only**. The dashboard create/update API has no field for it — `overrideDashboardTimeRange` is silently dropped on data charts and rejected on `Note`/`SmartFilter` (see [Fields Rejected on Create](#fields-rejected-on-create-cross-chart)). To diverge a panel from the dashboard picker today, edit it in the UI (Edit panel → Time range → Custom); the JSON payload you POST cannot encode this.

--- a/skills/building-dashboards/reference/chart-cookbook.md
+++ b/skills/building-dashboards/reference/chart-cookbook.md
@@ -337,7 +337,18 @@ No APL needed—configure these fields for interactive filtering:
 
 ## Note
 
-Markdown panels for context and navigation.
+Markdown panels for context and navigation. The chart object carries Markdown in a **top-level `text`** field. There is no `query`, and `text` is **not** wrapped in an `options` object — the create API rejects `options` with `Unrecognized key: "options"`.
+
+```json
+{
+  "id": "dashboard-header",
+  "name": "API Gateway",
+  "type": "Note",
+  "text": "# API Gateway — Oncall\n\n**Purpose:** Quick triage."
+}
+```
+
+The recipes below are the Markdown that goes inside `text`. JSON-escape the content (newlines as `\n`, quotes as `\"`) when embedding it as the chart's `text` value.
 
 ### Dashboard Header
 ```markdown

--- a/skills/building-dashboards/reference/design-playbook.md
+++ b/skills/building-dashboards/reference/design-playbook.md
@@ -106,6 +106,21 @@ Users should be able to:
 **Problem:** "Errors", "Latency", "Traffic" don't explain what you're looking at.
 **Fix:** Question-style names: "Error rate by route", "p95 latency trend", "Requests per minute".
 
+### Substituting a Different Quantity for the Asked One
+**Problem:** A panel asks for X (e.g. an availability ratio). X computation is blocked — the MPL parser doesn't support the ratio shape, a required tag is missing, the metric doesn't exist, etc. The author substitutes a related quantity Y (e.g. raw success count) and labels the panel "Y — X unavailable" or "Y replaces X."
+
+The substitution is dishonest in effect even when honestly labelled. The user reads Y's value and acts on it. The disclaimer text in the chart name or description doesn't propagate to whoever takes action on the number — the disclaimer lives on the panel; the action lives in the rest of someone's brain.
+
+**Fix:** If X can be computed, compute it. If X is blocked, **defer the panel with a Note** that documents what was supposed to be there and why. The rest of the dashboard ships normally. See [SKILL.md § Required: Compute What's Asked, or Defer With a Blocker](../SKILL.md#required-compute-whats-asked-or-defer-with-a-blocker) for the canonical Note-panel template.
+
+Common blocked-X cases:
+
+- The MPL parser doesn't support the ratio computation shape — use the existing ratio blueprint in `reference/promql-to-mpl.md § Ratios and division`; if the blueprint doesn't apply, defer.
+- A required tag is absent from the dataset and reverse-tag discovery (`metrics-info … tags`) finds no equivalent — defer; don't drop the dimension or substitute a different one.
+- The required metric doesn't exist in the dataset and OTel rename rules don't produce one that does — defer; don't render a different metric labelled with the original's name.
+
+**Why a Note and not silent omission?** Silent omission ships a dashboard that looks complete but is missing a question the user asked. Six months later, the next author can't tell whether the panel was forgotten, deemed unnecessary, or deferred for cause. A Note panel records the audit trail in the same layout slot, so the structural intent stays visible and grep-able for "Deferred".
+
 ---
 
 ## Golden Signals Coverage

--- a/skills/building-dashboards/reference/design-playbook.md
+++ b/skills/building-dashboards/reference/design-playbook.md
@@ -2,23 +2,13 @@
 
 ## Decision-First Design
 
-Every dashboard exists to help someone make a decision. Before adding panels, answer:
+Each panel must inform a decision. Before adding one, answer:
 
-1. **Who is the audience?**
-   - Oncall engineer (needs fast triage, error focus)
-   - Team lead (needs weekly trends, SLO tracking)
-   - Executive (needs high-level health, business impact)
+1. **Audience:** oncall (fast triage), team lead (weekly trends, SLO), executive (high-level health).
+2. **Decision:** "Should I page?" / "Which service?" / "Are we meeting SLOs?" / "What changed after deploy?"
+3. **Action:** rollback, scale, investigate, escalate, ignore.
 
-2. **What decisions will they make?**
-   - "Should I page someone?"
-   - "Which service is causing this?"
-   - "Are we meeting our SLOs?"
-   - "What changed after the deploy?"
-
-3. **What actions follow?**
-   - Rollback, scale, investigate, escalate, ignore
-
-If a panel doesn't inform a decision → remove it.
+No decision → no panel.
 
 ---
 
@@ -39,10 +29,7 @@ Structure dashboards in layers:
 └─────────────────────────────────────────────────────────┘
 ```
 
-Users should be able to:
-1. Glance at overview → "something's wrong with errors"
-2. Scan drilldown → "it's the /checkout route"
-3. Dive into evidence → "null pointer in payment handler"
+Visual flow: glance overview ("errors are up") → scan drilldown ("on `/checkout`") → dive into evidence ("null pointer in payment handler").
 
 ---
 
@@ -107,19 +94,18 @@ Users should be able to:
 **Fix:** Question-style names: "Error rate by route", "p95 latency trend", "Requests per minute".
 
 ### Substituting a Different Quantity for the Asked One
-**Problem:** A panel asks for X (e.g. an availability ratio). X computation is blocked — the MPL parser doesn't support the ratio shape, a required tag is missing, the metric doesn't exist, etc. The author substitutes a related quantity Y (e.g. raw success count) and labels the panel "Y — X unavailable" or "Y replaces X."
+**Problem:** A panel asks for X (an availability ratio, say). X is blocked — parser limit, missing tag, missing metric. The author ships a different quantity Y labelled "Y replaces X."
 
-The substitution is dishonest in effect even when honestly labelled. The user reads Y's value and acts on it. The disclaimer text in the chart name or description doesn't propagate to whoever takes action on the number — the disclaimer lives on the panel; the action lives in the rest of someone's brain.
+The disclaimer doesn't propagate to whoever acts on the number. The user reads Y's value and takes action; the panel-level caveat stays on the panel.
 
-**Fix:** If X can be computed, compute it. If X is blocked, **defer the panel with a Note** that documents what was supposed to be there and why. The rest of the dashboard ships normally. See [SKILL.md § Required: Compute What's Asked, or Defer With a Blocker](../SKILL.md#required-compute-whats-asked-or-defer-with-a-blocker) for the canonical Note-panel template.
+**Fix:** Defer with a `Note` panel in the same layout slot. See [SKILL.md § Compute or Defer](../SKILL.md#compute-or-defer) for the template.
 
 Common blocked-X cases:
+- MPL parser can't express the ratio — try the blueprint in [`promql-to-mpl.md § Ratios`](./promql-to-mpl.md#ratios-and-division-compute--using-); if not applicable, defer.
+- Required tag absent + reverse-tag discovery yields no equivalent — defer.
+- Required metric absent + OTel rename rules yield no match — defer.
 
-- The MPL parser doesn't support the ratio computation shape — use the existing ratio blueprint in `reference/promql-to-mpl.md § Ratios and division`; if the blueprint doesn't apply, defer.
-- A required tag is absent from the dataset and reverse-tag discovery (`metrics-info … tags`) finds no equivalent — defer; don't drop the dimension or substitute a different one.
-- The required metric doesn't exist in the dataset and OTel rename rules don't produce one that does — defer; don't render a different metric labelled with the original's name.
-
-**Why a Note and not silent omission?** Silent omission ships a dashboard that looks complete but is missing a question the user asked. Six months later, the next author can't tell whether the panel was forgotten, deemed unnecessary, or deferred for cause. A Note panel records the audit trail in the same layout slot, so the structural intent stays visible and grep-able for "Deferred".
+Silent omission is worse than deferral: six months later, the next author can't tell whether a missing panel was forgotten or deferred for cause. A Note keeps the audit trail in place.
 
 ---
 

--- a/skills/building-dashboards/reference/grafana-migration.md
+++ b/skills/building-dashboards/reference/grafana-migration.md
@@ -1,0 +1,230 @@
+# Grafana Dashboard Migration
+
+Guide for converting Grafana dashboards (Prometheus-backed) to Axiom dashboards on a metrics dataset.
+
+> **Headline rule.** A Grafana panel's spec is the **union of five fields**. No single field is the whole spec. Pull them together in your *first* projection and use their conjunction when authoring the MPL equivalent. The most common failure mode in this migration is reading one field and silently ignoring another — the resulting dashboard filters or groups on a different subset than the original, however honestly it claims to "match".
+
+---
+
+## Migration Workflow
+
+1. **Export the Grafana dashboard JSON** (UI: Share → Export → Save to file, or via the Grafana HTTP API).
+2. **Project the canonical panel spec** for every panel — `expr`, `legendFormat`, `unit`, `title`, `description`. Use the `jq` recipe below. **Mandatory.** Skipping this step is the F4 failure mode.
+3. **Reconcile prose against `expr`** for each panel — more-restrictive wins (see "Reconciling description and expr").
+4. **Map visualization types** Grafana → Axiom (table below).
+5. **Translate PromQL → MPL** preserving every selector and grouping. See `reference/promql-to-mpl.md` for the full rules; the short version is in this file.
+6. **Resolve metric/label name mismatches** by applying Prometheus → OTel renaming rules first, then validating with `scripts/metrics/metrics-info`. Only escalate after both steps fail.
+7. **Test queries** with `scripts/metrics/metrics-query`, keeping `$__interval` verbatim — do not rewrite it to a fixed duration just to make the test pass.
+8. **Build the Axiom dashboard JSON** starting from [`reference/templates/blank.json`](./templates/blank.json) — do **not** carry the Grafana wrapper forward. The blank skeleton has the correct `refreshTime`, `schemaVersion`, and `timeWindowStart`/`End` defaults; populate `name`, `description`, `datasets`, `charts`, and `layout`. See [Top-Level Dashboard Fields](#top-level-dashboard-fields) for the field-by-field translation when you do need to carry a value over (e.g. preserving the source refresh interval). Remove any inline time ranges from panel queries.
+9. **Validate and deploy** with `dashboard-validate` and `dashboard-create`. Get the URL via `dashboard-link` — never construct it.
+
+---
+
+## Canonical Panel Spec — Pull Every Field
+
+A Grafana panel carries spec information across multiple top-level fields. Each one carries something the others do not:
+
+| Field                              | What it carries                                                                                              |
+|:-----------------------------------|:-------------------------------------------------------------------------------------------------------------|
+| `targets[*].expr`                  | The PromQL — selectors (`{label="x"}`), groupings (`by(label, …)`), aggregations, math.                      |
+| `targets[*].legendFormat`          | Per-series labelling. `{{ resource }}` reveals "this panel groups by `resource`" even when the PromQL hides it. |
+| `fieldConfig.defaults.unit`        | Display unit (Grafana enum — `s`, `bytes`, `percentunit`, etc.). Maps to Axiom `unit`/`customUnits`.          |
+| `title`                            | Human-facing label. Often names the quantity ("p95 read request latency") that the PromQL implements.        |
+| `description`                      | **Narrative constraints.** Often enumerates subsets, references, or intent in prose that does not appear verbatim in `expr` (e.g. "failed checkout attempts in the EU region over the last 24h, grouped by payment provider"). |
+
+### `jq` projection
+
+Run this against the exported dashboard JSON before authoring any MPL:
+
+```bash
+jq '
+  .panels[]?
+  | {
+      title,
+      description,
+      unit: .fieldConfig.defaults.unit,
+      targets: ((.targets // []) | map({expr, legendFormat, refId}))
+    }
+' grafana-dashboard.json
+```
+
+**Multi-target panels are normal.** A single panel can have several `targets` (e.g. one for `total`, one for `errors`, so the panel can compute a ratio in Grafana's transform layer). Iterate `targets[]`, not `targets[0]`. Translate every entry. Dropping the second target loses half the panel.
+
+**Nested rows.** Grafana groups panels under "row" panels with their own `panels` array. If your dashboard uses rows, recurse:
+
+```bash
+jq '
+  [ .panels[]?, (.panels[]? | .panels[]?) ]
+  | map(select(.type != "row"))
+  | .[]
+  | { title, description, unit: .fieldConfig.defaults.unit,
+      targets: ((.targets // []) | map({expr, legendFormat, refId})) }
+' grafana-dashboard.json
+```
+
+### The conjunction rule
+
+The five fields together **are** the spec. Pull them together; reason about them together; author the MPL using their conjunction.
+
+- `description` adds narrative context. It does not replace `expr`.
+- `expr` carries machine-readable structure. It does not replace `description`.
+- `legendFormat` reveals grouping intent that may not be obvious from `expr` alone.
+- `unit` and `title` together drive the chart's unit configuration on the Axiom side.
+
+The skill's job is to make sure the agent reads what the source dashboard already wrote down. The source dashboard carries the domain knowledge.
+
+---
+
+## Reconciling description and expr
+
+When `description` and `expr` *appear* to disagree on what the panel measures, both were deliberate authoring choices. The rule:
+
+| Situation                                                        | Resolution                                                                                                       |
+|:-----------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------|
+| `description` enumerates a *narrower* subset than `expr` filters | **Prose wins.** The narrower constraint was intentional; the `expr` may have been left broader for tooling reasons. |
+| `description` enumerates a *broader* concept than `expr` filters | **`expr` wins.** Concrete machinery beats aspirational prose; the panel was deployed in the narrower form.        |
+| `description` is missing or empty                                | Use `expr` + `legendFormat` alone. **Do not widen the subset via discovery to fill the gap.** Absence is not authorization. |
+| `description` and `expr` agree                                   | The conjunction is the spec. Translate both.                                                                     |
+
+Rule of thumb when both are present and disagree: **the more-restrictive constraint wins**. Both fields were authored deliberately; the prose constraint was put there for a reason.
+
+---
+
+## Visualization Type Mapping
+
+| Grafana panel type | Axiom chart type      | Notes                                                                                              |
+|:-------------------|:----------------------|:---------------------------------------------------------------------------------------------------|
+| `timeseries`       | TimeSeries            | Direct mapping. Preserve grouping dimensions in MPL `group by`.                                    |
+| `stat`             | Statistic             | Requires `customUnits`, not `unit` (the create API rejects `unit` on Statistic). See `chart-config.md`. |
+| `gauge`            | Statistic             | Map thresholds to `warningThreshold` / `errorThreshold`. Statistic does not draw a dial; the value + threshold colour is the equivalent signal. |
+| `bargauge`         | Statistic or Table    | Single value → Statistic. Multi-row → Table sorted by the value column.                            |
+| `table`            | Table                 | Direct. Preserve column projections.                                                               |
+| `heatmap`          | Heatmap               | Histograms map to `summarize histogram(...) by bin_auto(_time)` on APL datasets; for OTel histogram metrics, see `metrics-mpl.md`. |
+| `piechart`         | Pie                   | Pie is for ≤6 slices — refuse to translate a pie of unbounded cardinality, switch to Table.        |
+| `text`             | Note                  | Body is GitHub-flavored markdown. **Lift Grafana's `options.content` to a top-level `text` field on the Axiom chart** (Axiom rejects `options{}` on every chart kind, and rejects `[charts N text]: expected string, received undefined` if `text` is missing). Strip the Grafana panel's chart-level `description` — it is also universally rejected. See [Note Options](./chart-config.md#note-options) and [Fields Rejected on Create](./chart-config.md#fields-rejected-on-create-cross-chart). |
+| `logs`             | LogStream             | Only when the source data is logs (events dataset), not a metrics dataset.                         |
+| `barchart`, `histogram` | TimeSeries (variant `bars`) or Table | Choose by whether the x-axis is `_time` (TimeSeries with bar variant) or a category (Table). |
+| `row`              | (none — recurse)      | A row groups child panels; project its `panels` array.                                             |
+
+---
+
+## Top-Level Dashboard Fields
+
+Grafana and Axiom dashboard wrappers use different field names, types, and value formats. Carrying the Grafana wrapper through verbatim fails: `refreshTime` rejects the string form, `schemaVersion: 0` is promoted to a strict-mode failure by `dashboard-validate`, and Grafana's `time` block has no Axiom equivalent.
+
+The canonical move is to start from [`reference/templates/blank.json`](./templates/blank.json) and only translate the Grafana fields you actually want to preserve.
+
+| Grafana field | Axiom field | Translation |
+|:---|:---|:---|
+| `title` | `name` | Direct copy. |
+| `description` (dashboard-level) | `description` (dashboard-level) | Direct copy. Note: chart-level `description` is rejected on every chart kind — see [Fields Rejected on Create](./chart-config.md#fields-rejected-on-create-cross-chart). |
+| `refresh` (string, e.g. `"10s"`, `"5m"`) | `refreshTime` (integer seconds) | Convert: `"10s"` → `10`, `"30s"` → `30`, `"1m"` → `60`, `"5m"` → `300`. Sending the string form fails with `unmarshal dashboard document: json: cannot unmarshal string into Go struct field Dashboard.refreshTime of type int64`. Default in `blank.json` is `60`. |
+| `schemaVersion` (integer, often `0` or Grafana's current version like `39`) | `schemaVersion` | Always set to `2` — the Axiom dashboard schema is unrelated to Grafana's. `schemaVersion: 0` triggers a `dashboard-validate --strict` failure. |
+| `time.from`, `time.to` (e.g. `"now-6h"`, `"now"`) | `timeWindowStart`, `timeWindowEnd` | Prefix with `qr-`: `"now-6h"` → `"qr-now-6h"`, `"now"` → `"qr-now"`. The bare `"now"` form fails with `[timeWindowStart]: expected string, received null` if omitted. Defaults in `blank.json`: `"qr-now-1h"` / `"qr-now"`. |
+| `panels` (array of panel specs) | `charts` (array) + `layout` (array) | Per-panel translation, plus a separate layout array. Grafana's `gridPos` becomes layout entries with `i`, `x`, `y`, `w`, `h`. |
+| `templating.list` (variables) | SmartFilter chart (separate kind) | Not a direct field copy. See `reference/smartfilter.md` if the source uses dashboard variables. |
+| `tags`, `uid`, `id`, `version`, `iteration`, `weekStart`, `style`, `editable`, `graphTooltip`, `liveNow`, `timezone`, `fiscalYearStartMonth`, `annotations`, `links` | — | Drop. No Axiom equivalent. (Annotations on individual charts use a different mechanism — see [chart-config.md § Annotations](./chart-config.md#annotations).) |
+| `datasource` (per-panel or default) | `datasets` (top-level array) + `query.metricsDataset` (per-chart) | Resolve the Prometheus datasource name to the Axiom metrics dataset hosting the OTel-ingested data; populate the dataset name in both places. |
+
+The `owner` field has no Grafana equivalent — set it to `"X-AXIOM-EVERYONE"` (or a specific org/user/team identifier) as the blank skeleton does.
+
+---
+
+## PromQL → MPL: Preserve Every Selector and Grouping
+
+Full rules: [reference/promql-to-mpl.md](./promql-to-mpl.md). Headline guarantees you must enforce regardless:
+
+- **Every PromQL `{label="x"}` becomes an MPL `where` clause.** Never drop a selector because the metric name "feels" scoped to the right thing — the selector was an authoring decision.
+- **Every PromQL `by(label1, label2)` dimension becomes an MPL `group by`.** Drop one and the chart shape changes.
+- **Aggregations** (`rate()`, `sum()`, `histogram_quantile()`) translate to MPL operators — consult `scripts/metrics/metrics-spec` for the operator names per metric type before authoring. The `promql-to-mpl.md` doc covers the common operator mappings (rate → `align using prom::rate`, histogram_quantile → `bucket … using interpolate_*_histogram`, etc.).
+
+**Discovery is a validator, not a generator.** Discovery (`metrics-info`, `metrics-query`) confirms that the subset described by `expr`+`description` exists in the dataset. It does not invent a subset for you. If you find yourself running discovery to *decide* what the panel should filter on, stop — the source dashboard already wrote that down.
+
+---
+
+## Name Mapping: PromQL ↔ OTel Ingest
+
+When a metric or label name from `expr` does not appear verbatim in the Axiom dataset, the **first** move is not trial-and-error and not "metrics-info to look for similar names". The first move is applying the deterministic Prometheus → OTel renaming rules.
+
+### Common transformations
+
+These rules are stable; the canonical reference (the OpenTelemetry specification's "Prometheus and OpenMetrics Compatibility" page) carries the full table and any newer additions.
+
+| PromQL form                                       | OTel form (post-ingest)                                  | Notes                                                                                                                            |
+|:--------------------------------------------------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------|
+| `<metric>_total`                                  | `<metric>` (counter type)                                | The `_total` suffix is dropped on OTel ingest; counter-ness is carried as metric metadata, not as a name suffix.                 |
+| `<metric>_bucket`, `<metric>_sum`, `<metric>_count` | `<metric>` (Histogram type)                              | A Prometheus histogram's three derived series collapse into one OTel `Histogram` metric. Use the Histogram-type MPL operators.   |
+| `<metric>_seconds`, `<metric>_bytes`, `<metric>_milliseconds` | Often unchanged; sometimes carried in `unit` metadata | Unit suffixes are sometimes preserved in the metric name and sometimes only in the metric's `unit` metadata. Validate both ways. |
+
+These metric-name rules are stable. **Label names are different.** The OTel→Prom direction (OTel attribute `foo.bar` exposed as Prom label `foo_bar`) is convention, but the reverse is not safe to assume. A Prom label like `job` is *not* a renamed OTel attribute. A Prom label like `service_name` *might* be the OTel attribute `service.name`, or it might just be a Prom label called `service_name`. Resolve label names through reverse-tag discovery (next section), not through assumed renaming. When you do try a dotted form (`service.name`) as a candidate, back-tick it in MPL: `` `service.name` ``.
+
+### Order of operations
+
+1. **For metric names:** apply the rename rules (deterministic, free, first).
+2. **Validate with `metrics-info`:**
+   - `scripts/metrics/metrics-info <deploy> <dataset> metrics <renamed-name> info` for metrics.
+   - `scripts/metrics/metrics-info <deploy> <dataset> tags <label> values` for labels (start from the original Prom label; reverse-search if absent).
+3. **Surface the mismatch** only after both steps fail. Do not silently swap to a "looks similar" name.
+
+Find the live OpenTelemetry specification's "Prometheus and OpenMetrics Compatibility" page for the authoritative metric-name table — these rules evolve, so consult the spec rather than memorizing.
+
+---
+
+## Reverse-Tag Discovery for Missing Labels
+
+When a PromQL label name does not exist verbatim in the MPL dataset *after* applying the OTel rename rules — for example, PromQL has `{job="ingest-worker"}` but the dataset has no `job` tag — **do not drop the selector**. Reverse-search:
+
+1. **List all tags in the dataset:**
+   ```bash
+   scripts/metrics/metrics-info <deploy> <dataset> tags
+   ```
+2. **Inspect candidate values:**
+   ```bash
+   scripts/metrics/metrics-info <deploy> <dataset> tags <candidate> values
+   ```
+3. **Map the selector** to the equivalent tag once a value confirms it (e.g. PromQL `job=ingest-worker` → MPL `where service.name == "ingest-worker"` if the dataset uses `service.name`).
+4. **If no equivalent exists,** surface the mismatch to the user and document the panel as deferred. **Do not silently drop the selector** — that ships a wrong-shape dashboard.
+
+> Note: `find-metrics` is not the right tool here. It searches **tag values**, not tag names — useful when you know an entity name and want to find which metrics carry it, not for label-name reverse-search.
+
+---
+
+## Common Migration Pitfalls
+
+### Pulling `expr` but ignoring `description` (or vice versa)
+The classic F4 failure. The fields are complementary, not redundant. `expr` is machine-readable; `description` carries narrative constraints, intent, and subset enumerations the panel author wrote down deliberately. The MPL equivalent must reflect both. **Fix:** always project the canonical panel spec (all five fields) before authoring.
+
+### Using discovery to invent the subset
+Symptom: agent runs `metrics-info`, finds N metrics in the dataset, picks the few that "look right", ships those. That is invention, not translation. The source dashboard already wrote down the subset; the agent's job is to translate it, not redesign it. **Fix:** discovery confirms the spec'd subset exists; it does not generate the subset.
+
+### Hand-rolling renaming guesses before consulting the spec
+Symptom: `http_requests_total` doesn't exist verbatim → agent tries `http_requests`, then `http_request_count`, then `requests`. **Fix:** apply the OTel renaming rules deterministically (drop `_total`, keep the rest), validate with `metrics-info`, escalate if both fail. Do not iterate on guesses.
+
+### Multi-target panels with one target translated
+Symptom: a Grafana panel with two `targets` (e.g. `total` and `errors`) translates to a single MPL pipeline. **Fix:** project `targets[]` plural; translate every entry; combine in MPL or split into two panels if the original used Grafana transforms.
+
+### Substituting a different quantity when blocked
+Symptom: the requested ratio cannot be computed (parser limit, missing tag), agent ships a different quantity Y labelled "Y replaces X". This is never acceptable, however honestly disclosed. **Fix:** mark the panel as deferred with a Note panel naming the blocker, and ship the rest of the dashboard. (Fuller rule lands as item C1 in the skill's fix plan.)
+
+### Translating against a "live" Grafana instance instead of the exported JSON
+Symptom: agent screen-scrapes a Grafana panel and translates from the rendered chart. **Fix:** always work from the exported JSON. The panel text shown in the UI is generated from `title` + `legendFormat` and may obscure parts of the spec.
+
+---
+
+## Migration Checklist
+
+- [ ] Exported Grafana dashboard JSON (or fetched via Grafana API).
+- [ ] Projected canonical panel spec via `jq` — every panel's `expr`, `legendFormat`, `unit`, `title`, `description`.
+- [ ] For every panel, listed the spec as the conjunction of its five fields; reconciled prose against `expr` (more-restrictive wins).
+- [ ] Mapped visualization types per the table above.
+- [ ] For every metric/label name in `expr`: applied OTel renaming rules first, validated with `metrics-info`, escalated only if both failed.
+- [ ] For every PromQL `{...}` selector: a corresponding MPL `where` clause.
+- [ ] **For every PromQL selector value not present in `metrics-info … tags <label> values`: cited a written source for the expansion** (panel `description`, or upstream rule library file + line). Memory-as-source is forbidden; no citation → defer the panel. See [promql-to-mpl.md § Selector Values Not in the Dataset Are Aliases](./promql-to-mpl.md#selector-values-not-in-the-dataset-are-aliases--cite-the-source).
+- [ ] For every PromQL `by(...)`: a corresponding MPL `group by` with all dimensions preserved.
+- [ ] Tested every query with `metrics-query`, preserving `$__interval` (with `param` declaration and `-p __interval=…`).
+- [ ] Built Axiom dashboard JSON without inline time ranges in chart queries.
+- [ ] Set chart units correctly: `customUnits` on Statistic, `unit` on TimeSeries (see `chart-config.md`).
+- [ ] Validated with `dashboard-validate`.
+- [ ] Deployed with `dashboard-create`.
+- [ ] Got the URL via `dashboard-link` (never constructed manually).
+- [ ] Compared panel-by-panel to the original: does each panel filter the same subset and group by the same dimensions?

--- a/skills/building-dashboards/reference/grafana-migration.md
+++ b/skills/building-dashboards/reference/grafana-migration.md
@@ -8,15 +8,15 @@ Guide for converting Grafana dashboards (Prometheus-backed) to Axiom dashboards 
 
 ## Migration Workflow
 
-1. **Export the Grafana dashboard JSON** (UI: Share → Export → Save to file, or via the Grafana HTTP API).
-2. **Project the canonical panel spec** for every panel — `expr`, `legendFormat`, `unit`, `title`, `description`. Use the `jq` recipe below. **Mandatory.** Skipping this step is the F4 failure mode.
-3. **Reconcile prose against `expr`** for each panel — more-restrictive wins (see "Reconciling description and expr").
-4. **Map visualization types** Grafana → Axiom (table below).
-5. **Translate PromQL → MPL** preserving every selector and grouping. See `reference/promql-to-mpl.md` for the full rules; the short version is in this file.
-6. **Resolve metric/label name mismatches** by applying Prometheus → OTel renaming rules first, then validating with `scripts/metrics/metrics-info`. Only escalate after both steps fail.
-7. **Test queries** with `scripts/metrics/metrics-query`, keeping `$__interval` verbatim — do not rewrite it to a fixed duration just to make the test pass.
-8. **Build the Axiom dashboard JSON** starting from [`reference/templates/blank.json`](./templates/blank.json) — do **not** carry the Grafana wrapper forward. The blank skeleton has the correct `refreshTime`, `schemaVersion`, and `timeWindowStart`/`End` defaults; populate `name`, `description`, `datasets`, `charts`, and `layout`. See [Top-Level Dashboard Fields](#top-level-dashboard-fields) for the field-by-field translation when you do need to carry a value over (e.g. preserving the source refresh interval). Remove any inline time ranges from panel queries.
-9. **Validate and deploy** with `dashboard-validate` and `dashboard-create`. Get the URL via `dashboard-link` — never construct it.
+1. **Export the Grafana dashboard JSON** (Share → Export, or Grafana HTTP API).
+2. **Project the canonical panel spec** for every panel — `expr`, `legendFormat`, `unit`, `title`, `description`. Use the `jq` recipe below. Skipping this step is the most common failure mode.
+3. **Reconcile prose against `expr`** — more-restrictive wins. See [Reconciling description and expr](#reconciling-description-and-expr).
+4. **Map visualization types** (table below).
+5. **Translate PromQL → MPL** preserving every selector and grouping. Full rules: [`promql-to-mpl.md`](./promql-to-mpl.md).
+6. **Resolve metric/label name mismatches** by applying OTel renaming rules first, then validating with `metrics-info`. Escalate only after both fail.
+7. **Validate each query** with `scripts/metrics/mpl-validate-chart` (preserves `$__interval`).
+8. **Compose the Axiom dashboard** with `chart-add` + `layout-pack` + `dashboard-assemble`. For top-level field mappings (`refresh` → `refreshTime`, `time.from` → `timeWindowStart` with `qr-` prefix, etc.) see [Top-Level Dashboard Fields](#top-level-dashboard-fields).
+9. **Deploy** with `dashboard-create`; URL via `dashboard-link`.
 
 ---
 
@@ -64,14 +64,12 @@ jq '
 
 ### The conjunction rule
 
-The five fields together **are** the spec. Pull them together; reason about them together; author the MPL using their conjunction.
+The five fields together **are** the spec. Author the MPL from their conjunction:
 
-- `description` adds narrative context. It does not replace `expr`.
-- `expr` carries machine-readable structure. It does not replace `description`.
-- `legendFormat` reveals grouping intent that may not be obvious from `expr` alone.
-- `unit` and `title` together drive the chart's unit configuration on the Axiom side.
-
-The skill's job is to make sure the agent reads what the source dashboard already wrote down. The source dashboard carries the domain knowledge.
+- `description` adds narrative constraints — does not replace `expr`.
+- `expr` carries machine-readable structure — does not replace `description`.
+- `legendFormat` reveals grouping intent often hidden in `expr`.
+- `unit` + `title` drive chart unit configuration on the Axiom side.
 
 ---
 
@@ -101,7 +99,7 @@ Rule of thumb when both are present and disagree: **the more-restrictive constra
 | `table`            | Table                 | Direct. Preserve column projections.                                                               |
 | `heatmap`          | Heatmap               | Histograms map to `summarize histogram(...) by bin_auto(_time)` on APL datasets; for OTel histogram metrics, see `metrics-mpl.md`. |
 | `piechart`         | Pie                   | Pie is for ≤6 slices — refuse to translate a pie of unbounded cardinality, switch to Table.        |
-| `text`             | Note                  | Body is GitHub-flavored markdown. **Lift Grafana's `options.content` to a top-level `text` field on the Axiom chart** (Axiom rejects `options{}` on every chart kind, and rejects `[charts N text]: expected string, received undefined` if `text` is missing). Strip the Grafana panel's chart-level `description` — it is also universally rejected. See [Note Options](./chart-config.md#note-options) and [Fields Rejected on Create](./chart-config.md#fields-rejected-on-create-cross-chart). |
+| `text`             | Note                  | `chart-add --type Note --text "<md>"` handles the shape (top-level `text`, no `options{}` wrapper). Strip Grafana's chart-level `description` — universally rejected. |
 | `logs`             | LogStream             | Only when the source data is logs (events dataset), not a metrics dataset.                         |
 | `barchart`, `histogram` | TimeSeries (variant `bars`) or Table | Choose by whether the x-axis is `_time` (TimeSeries with bar variant) or a category (Table). |
 | `row`              | (none — recurse)      | A row groups child panels; project its `panels` array.                                             |
@@ -117,7 +115,7 @@ The canonical move is to start from [`reference/templates/blank.json`](./templat
 | Grafana field | Axiom field | Translation |
 |:---|:---|:---|
 | `title` | `name` | Direct copy. |
-| `description` (dashboard-level) | `description` (dashboard-level) | Direct copy. Note: chart-level `description` is rejected on every chart kind — see [Fields Rejected on Create](./chart-config.md#fields-rejected-on-create-cross-chart). |
+| `description` (dashboard-level) | `description` (dashboard-level) | Direct copy. Chart-level `description` is rejected on every chart kind — see [chart-config.md § Fields Rejected on Create](./chart-config.md#fields-rejected-on-create). |
 | `refresh` (string, e.g. `"10s"`, `"5m"`) | `refreshTime` (integer seconds) | Convert: `"10s"` → `10`, `"30s"` → `30`, `"1m"` → `60`, `"5m"` → `300`. Sending the string form fails with `unmarshal dashboard document: json: cannot unmarshal string into Go struct field Dashboard.refreshTime of type int64`. Default in `blank.json` is `60`. |
 | `schemaVersion` (integer, often `0` or Grafana's current version like `39`) | `schemaVersion` | Always set to `2` — the Axiom dashboard schema is unrelated to Grafana's. `schemaVersion: 0` triggers a `dashboard-validate --strict` failure. |
 | `time.from`, `time.to` (e.g. `"now-6h"`, `"now"`) | `timeWindowStart`, `timeWindowEnd` | Prefix with `qr-`: `"now-6h"` → `"qr-now-6h"`, `"now"` → `"qr-now"`. The bare `"now"` form fails with `[timeWindowStart]: expected string, received null` if omitted. Defaults in `blank.json`: `"qr-now-1h"` / `"qr-now"`. |
@@ -192,22 +190,22 @@ When a PromQL label name does not exist verbatim in the MPL dataset *after* appl
 ## Common Migration Pitfalls
 
 ### Pulling `expr` but ignoring `description` (or vice versa)
-The classic F4 failure. The fields are complementary, not redundant. `expr` is machine-readable; `description` carries narrative constraints, intent, and subset enumerations the panel author wrote down deliberately. The MPL equivalent must reflect both. **Fix:** always project the canonical panel spec (all five fields) before authoring.
+The most common failure. The fields are complementary. `expr` is machine-readable; `description` carries narrative constraints. **Fix:** always project all five fields before authoring.
 
 ### Using discovery to invent the subset
-Symptom: agent runs `metrics-info`, finds N metrics in the dataset, picks the few that "look right", ships those. That is invention, not translation. The source dashboard already wrote down the subset; the agent's job is to translate it, not redesign it. **Fix:** discovery confirms the spec'd subset exists; it does not generate the subset.
+Symptom: agent runs `metrics-info`, picks metrics that "look right", ships those. That's invention, not translation. **Fix:** discovery confirms the spec'd subset exists; it doesn't generate it.
 
-### Hand-rolling renaming guesses before consulting the spec
-Symptom: `http_requests_total` doesn't exist verbatim → agent tries `http_requests`, then `http_request_count`, then `requests`. **Fix:** apply the OTel renaming rules deterministically (drop `_total`, keep the rest), validate with `metrics-info`, escalate if both fail. Do not iterate on guesses.
+### Hand-rolling rename guesses
+Symptom: `http_requests_total` not found → tries `http_requests`, `http_request_count`, … **Fix:** apply OTel rename rules deterministically (drop `_total`), validate once with `metrics-info`, escalate.
 
-### Multi-target panels with one target translated
-Symptom: a Grafana panel with two `targets` (e.g. `total` and `errors`) translates to a single MPL pipeline. **Fix:** project `targets[]` plural; translate every entry; combine in MPL or split into two panels if the original used Grafana transforms.
+### Multi-target panels translated as one
+Symptom: a panel with `total` + `errors` targets becomes a single MPL pipeline. **Fix:** iterate `targets[]`; translate every entry. Combine in MPL or split into two panels if Grafana used transforms.
 
 ### Substituting a different quantity when blocked
-Symptom: the requested ratio cannot be computed (parser limit, missing tag), agent ships a different quantity Y labelled "Y replaces X". This is never acceptable, however honestly disclosed. **Fix:** mark the panel as deferred with a Note panel naming the blocker, and ship the rest of the dashboard. (Fuller rule lands as item C1 in the skill's fix plan.)
+Symptom: ratio can't be computed → agent ships a related quantity Y labelled "Y replaces X". Never acceptable. **Fix:** defer the panel with a Note documenting the blocker. See [SKILL.md § Compute or Defer](../SKILL.md#compute-or-defer).
 
-### Translating against a "live" Grafana instance instead of the exported JSON
-Symptom: agent screen-scrapes a Grafana panel and translates from the rendered chart. **Fix:** always work from the exported JSON. The panel text shown in the UI is generated from `title` + `legendFormat` and may obscure parts of the spec.
+### Translating from the live Grafana UI instead of the export
+Symptom: agent screen-scrapes the rendered chart. **Fix:** always work from the exported JSON — UI text is generated from `title` + `legendFormat` and obscures parts of the spec.
 
 ---
 

--- a/skills/building-dashboards/reference/layout-recipes.md
+++ b/skills/building-dashboards/reference/layout-recipes.md
@@ -1,226 +1,96 @@
 # Layout Recipes
 
-Grid-based layout patterns for common dashboard structures.
+Section blueprints for common dashboard structures. The grid is **12 columns wide**; `dashboard-validate` rejects entries past column 12. `scripts/layout-pack` packs ordered ids into the grid using per-type defaults — most recipes below are expressible as a `layout-pack` invocation.
 
----
+Default per-type sizes (from `layout-pack`): Statistic 3×3, TimeSeries 6×4, Heatmap 6×4, Pie 4×4, Table 6×5, LogStream 12×6, Note 12×2, MonitorList 6×4, SmartFilter 12×1.
 
-## Grid Basics
+## Service Overview (oncall)
 
-- **Dashboard width:** 24 units
-- **Minimum panel width:** 3 units
-- **Panel positioning:** (x, y) coordinates with (w)idth and (h)eight
+Stats row → trend row → breakdowns → evidence.
 
-### Common Panel Sizes
-
-| Panel type | Width (w) | Height (h) | Description |
-|------------|-----------|------------|-------------|
-| Statistic (compact) | 6 | 2 | Quarter width, KPI |
-| Statistic (large) | 8 | 3 | Third width, featured KPI |
-| TimeSeries (half) | 12 | 4 | Side-by-side charts |
-| TimeSeries (full) | 24 | 4–6 | Full-width trend |
-| Table (half) | 12 | 4–6 | Side-by-side tables |
-| Table (full) | 24 | 5–8 | Detailed breakdown |
-| Pie | 8–12 | 4 | Share visualization |
-| LogStream | 24 | 6–10 | Raw events |
-| Note (header) | 24 | 1–2 | Section title |
-| SmartFilter | 24 | 2 | Dashboard filters |
-
----
-
-## Service Overview Layout
-
-Classic 4-section structure for oncall dashboards.
-
-```
-┌──────────────────────────────────────────────────────────────────────────────┐
-│ Row 0-1: Stats (h=2)                                                          │
-│ ┌─────────────┬─────────────┬─────────────┬─────────────┐                    │
-│ │ Error Rate  │ p95 Latency │ Traffic/s   │ Active      │                    │
-│ │ x=0, w=6    │ x=6, w=6    │ x=12, w=6   │ Alerts x=18 │                    │
-│ └─────────────┴─────────────┴─────────────┴─────────────┘                    │
-├──────────────────────────────────────────────────────────────────────────────┤
-│ Row 2-5: TimeSeries (h=4)                                                     │
-│ ┌────────────────────────────────┬────────────────────────────────┐          │
-│ │ Traffic + Errors Over Time     │ Latency Percentiles            │          │
-│ │ x=0, w=12                      │ x=12, w=12                     │          │
-│ └────────────────────────────────┴────────────────────────────────┘          │
-├──────────────────────────────────────────────────────────────────────────────┤
-│ Row 6-9: Tables (h=4)                                                         │
-│ ┌────────────────────────────────┬────────────────────────────────┐          │
-│ │ Top Failing Routes             │ Top Error Messages             │          │
-│ │ x=0, w=12                      │ x=12, w=12                     │          │
-│ └────────────────────────────────┴────────────────────────────────┘          │
-├──────────────────────────────────────────────────────────────────────────────┤
-│ Row 10-15: LogStream (h=6)                                                    │
-│ ┌────────────────────────────────────────────────────────────────────────────┐
-│ │ Recent Errors                                                               │
-│ │ x=0, w=24                                                                   │
-│ └────────────────────────────────────────────────────────────────────────────┘
-└──────────────────────────────────────────────────────────────────────────────┘
+```bash
+layout-pack \
+  err-rate:Statistic p95:Statistic traffic:Statistic alerts:Statistic \
+  traffic-ts:TimeSeries latency-ts:TimeSeries \
+  top-routes:Table top-errors:Table \
+  recent-errors:LogStream
 ```
 
-**Layout JSON:**
-```json
-[
-  {"i": "error-rate", "x": 0, "y": 0, "w": 6, "h": 2},
-  {"i": "p95-latency", "x": 6, "y": 0, "w": 6, "h": 2},
-  {"i": "traffic", "x": 12, "y": 0, "w": 6, "h": 2},
-  {"i": "alerts", "x": 18, "y": 0, "w": 6, "h": 2},
-  {"i": "traffic-errors-ts", "x": 0, "y": 2, "w": 12, "h": 4},
-  {"i": "latency-ts", "x": 12, "y": 2, "w": 12, "h": 4},
-  {"i": "top-routes", "x": 0, "y": 6, "w": 12, "h": 4},
-  {"i": "top-errors", "x": 12, "y": 6, "w": 12, "h": 4},
-  {"i": "logs", "x": 0, "y": 10, "w": 24, "h": 6}
-]
-```
-
----
-
-## Multi-Service Comparison Layout
-
-Side-by-side comparison of multiple services.
+Resulting grid:
 
 ```
-┌──────────────────────────────────────────────────────────────────────────────┐
-│ Row 0: SmartFilter                                                            │
-│ ┌────────────────────────────────────────────────────────────────────────────┐
-│ │ Filters: environment, region                                                │
-│ └────────────────────────────────────────────────────────────────────────────┘
-├──────────────────────────────────────────────────────────────────────────────┤
-│ Row 2-5: TimeSeries (by service)                                              │
-│ ┌────────────────────────────────────────────────────────────────────────────┐
-│ │ Traffic by Service (stacked)                                                │
-│ └────────────────────────────────────────────────────────────────────────────┘
-├──────────────────────────────────────────────────────────────────────────────┤
-│ Row 6-9: TimeSeries (by service)                                              │
-│ ┌────────────────────────────────────────────────────────────────────────────┐
-│ │ Error Rate by Service                                                       │
-│ └────────────────────────────────────────────────────────────────────────────┘
-├──────────────────────────────────────────────────────────────────────────────┤
-│ Row 10-13: Per-service columns                                                │
-│ ┌──────────────────┬──────────────────┬──────────────────┐                   │
-│ │ API Gateway      │ Auth Service     │ Payment Service  │                   │
-│ │ Stats + Table    │ Stats + Table    │ Stats + Table    │                   │
-│ └──────────────────┴──────────────────┴──────────────────┘                   │
-└──────────────────────────────────────────────────────────────────────────────┘
+y= 0  [err-rate 3] [p95 3] [traffic 3] [alerts 3]
+y= 3  [traffic-ts  6      ] [latency-ts  6       ]
+y= 7  [top-routes  6      ] [top-errors  6       ]
+y=12  [recent-errors            12               ]
 ```
 
----
+## Service Overview with Filter Bar
 
-## SLO Tracking Layout
+Add a SmartFilter row at the top (full-width, h=1):
 
-Focus on service level objectives and budget.
-
-```
-┌──────────────────────────────────────────────────────────────────────────────┐
-│ Row 0-2: SLO Stats (large)                                                    │
-│ ┌───────────────────┬───────────────────┬───────────────────┐                │
-│ │ Availability      │ Latency SLO       │ Error Budget      │                │
-│ │ 99.95%           │ p99 < 500ms       │ 23% remaining     │                │
-│ │ x=0, w=8, h=3     │ x=8, w=8, h=3     │ x=16, w=8, h=3    │                │
-│ └───────────────────┴───────────────────┴───────────────────┘                │
-├──────────────────────────────────────────────────────────────────────────────┤
-│ Row 3-8: SLO Trends                                                           │
-│ ┌────────────────────────────────────────────────────────────────────────────┐
-│ │ Availability Over Time (7d) with SLO threshold line                         │
-│ └────────────────────────────────────────────────────────────────────────────┘
-│ ┌────────────────────────────────────────────────────────────────────────────┐
-│ │ Error Budget Burn Rate                                                      │
-│ └────────────────────────────────────────────────────────────────────────────┘
-├──────────────────────────────────────────────────────────────────────────────┤
-│ Row 14+: SLO Violations                                                       │
-│ ┌────────────────────────────────────────────────────────────────────────────┐
-│ │ Table: SLO Violations by Route/Time                                         │
-│ └────────────────────────────────────────────────────────────────────────────┘
-└──────────────────────────────────────────────────────────────────────────────┘
+```bash
+layout-pack \
+  filters:SmartFilter \
+  err-rate:Statistic p95:Statistic traffic:Statistic alerts:Statistic \
+  …
 ```
 
----
+## SLO Tracking
 
-## Incident Investigation Layout
+Three SLO statistics across the top, two trend charts below, violations table at the bottom.
 
-Detailed drilldown for active incidents.
-
-```
-┌──────────────────────────────────────────────────────────────────────────────┐
-│ Row 0: SmartFilter (service, route, status, trace_id)                         │
-├──────────────────────────────────────────────────────────────────────────────┤
-│ Row 2-5: Impact Overview                                                      │
-│ ┌─────────────┬─────────────┬─────────────┬─────────────┐                    │
-│ │ Error Count │ Affected    │ Start Time  │ Duration    │                    │
-│ │             │ Customers   │             │             │                    │
-│ └─────────────┴─────────────┴─────────────┴─────────────┘                    │
-├──────────────────────────────────────────────────────────────────────────────┤
-│ Row 6-11: Timeline                                                            │
-│ ┌────────────────────────────────────────────────────────────────────────────┐
-│ │ Error Timeline (narrow bins, 10s-30s)                                       │
-│ └────────────────────────────────────────────────────────────────────────────┘
-├──────────────────────────────────────────────────────────────────────────────┤
-│ Row 12-17: Breakdown                                                          │
-│ ┌────────────────────────────────┬────────────────────────────────┐          │
-│ │ Errors by Route                │ Errors by Error Message        │          │
-│ └────────────────────────────────┴────────────────────────────────┘          │
-│ ┌────────────────────────────────┬────────────────────────────────┐          │
-│ │ Errors by Pod                  │ Errors by Customer             │          │
-│ └────────────────────────────────┴────────────────────────────────┘          │
-├──────────────────────────────────────────────────────────────────────────────┤
-│ Row 18+: Evidence (large LogStream)                                           │
-│ ┌────────────────────────────────────────────────────────────────────────────┐
-│ │ Raw Error Logs (h=10)                                                       │
-│ └────────────────────────────────────────────────────────────────────────────┘
-└──────────────────────────────────────────────────────────────────────────────┘
+```bash
+layout-pack \
+  avail:4x3 latency-slo:4x3 budget:4x3 \
+  avail-trend:TimeSeries burn-rate:TimeSeries \
+  violations:Table
 ```
 
----
+`Statistic` defaults to 3×3; override with `id:4x3` to fit three across.
+
+## Incident Investigation
+
+Filter bar → impact row → narrow-bin timeline → 4-way breakdown → tall LogStream.
+
+```bash
+layout-pack \
+  filters:SmartFilter \
+  err-count:Statistic affected:Statistic start:Statistic duration:Statistic \
+  err-timeline:12x4 \
+  by-route:Table by-message:Table \
+  by-pod:Table by-customer:Table \
+  raw-logs:12x10
+```
+
+## Multi-Service Comparison
+
+Filter bar → stacked-traffic full-width → error-rate full-width → per-service columns (each column is a `Statistic` + `Table` stack).
+
+```bash
+layout-pack \
+  filters:SmartFilter \
+  traffic-stacked:12x4 \
+  errors-by-service:12x4 \
+  api-stat:4x3 auth-stat:4x3 pay-stat:4x3 \
+  api-table:4x5 auth-table:4x5 pay-table:4x5
+```
 
 ## Kubernetes Cluster Overview
 
-Infrastructure-focused layout.
+Cluster-health stats → resource usage → pod issues → events.
 
-```
-┌──────────────────────────────────────────────────────────────────────────────┐
-│ Row 0: Cluster Health Stats                                                   │
-│ ┌─────────────┬─────────────┬─────────────┬─────────────┐                    │
-│ │ Nodes Ready │ Pods Running│ Restarts    │ OOMKills    │                    │
-│ └─────────────┴─────────────┴─────────────┴─────────────┘                    │
-├──────────────────────────────────────────────────────────────────────────────┤
-│ Row 2-5: Resource Usage                                                       │
-│ ┌────────────────────────────────┬────────────────────────────────┐          │
-│ │ CPU Usage by Namespace         │ Memory Usage by Namespace      │          │
-│ └────────────────────────────────┴────────────────────────────────┘          │
-├──────────────────────────────────────────────────────────────────────────────┤
-│ Row 6-9: Pod Issues                                                           │
-│ ┌────────────────────────────────┬────────────────────────────────┐          │
-│ │ Pods with Restarts             │ Pods with High CPU             │          │
-│ └────────────────────────────────┴────────────────────────────────┘          │
-├──────────────────────────────────────────────────────────────────────────────┤
-│ Row 10+: Events                                                               │
-│ ┌────────────────────────────────────────────────────────────────────────────┐
-│ │ Warning/Error Events (LogStream)                                            │
-│ └────────────────────────────────────────────────────────────────────────────┘
-└──────────────────────────────────────────────────────────────────────────────┘
+```bash
+layout-pack \
+  nodes:Statistic pods:Statistic restarts:Statistic oomkills:Statistic \
+  cpu-by-ns:TimeSeries mem-by-ns:TimeSeries \
+  pods-restarts:Table pods-cpu:Table \
+  events:LogStream
 ```
 
----
+## Best Practices
 
-## Layout Best Practices
-
-### Alignment
-- Align related panels vertically or horizontally
-- Keep consistent heights within rows
-- Don't mix units in adjacent panels without clear separation
-
-### Visual Hierarchy
-- Most important panels: top-left, larger
-- Supporting context: smaller, below/right
-- Evidence/logs: bottom, full-width
-
-### Responsive Considerations
-- Minimum useful width: w=6 for stats, w=12 for charts/tables
-- Full-width panels (w=24) for logs and complex tables
-- Test at common screen sizes
-
-### Section Separation
-- Use Note panels as section headers
-- Or use vertical spacing (leave y gaps)
-- Group related panels by theme/question
+- Keep adjacent panels at consistent heights within a row; mixed heights wrap correctly via `layout-pack`'s row-major fill but read as messy.
+- One question per panel. Split rather than overload.
+- Notes as section headers (`12x2`) instead of large vertical gaps.
+- Rule of thumb panel order: critical-top-left, supporting-context middle, evidence (LogStream) bottom.

--- a/skills/building-dashboards/reference/metrics-mpl.md
+++ b/skills/building-dashboards/reference/metrics-mpl.md
@@ -43,7 +43,7 @@ When generating metrics chart JSON:
 1. Confirm dataset kind is `otel:metrics:v1` via `scripts/metrics/datasets <deploy>`.
 2. Run `scripts/metrics/metrics-spec` to learn the full MPL syntax — **mandatory, never guess**.
 3. Discover available metrics and tags with `scripts/metrics/metrics-info`. If results are empty, retry with `--start` set to 7 days ago (sparse metrics may not have data in the default 24h window).
-4. **Read the metric's metadata** with `scripts/metrics/metrics-info <deploy> <dataset> metrics <metric> info`. The returned `{type, temporality, unit}` block drives both the query shape (see the `query-metrics` skill's "Choosing a query shape from metric metadata" section) and the chart unit configuration (see [Unit Handling](#unit-handling) below).
+4. **Read the metric's metadata** with `scripts/metrics/metrics-info <deploy> <dataset> metrics <metric> info`. The returned `{type, temporality, unit}` block drives both the query shape (see [Choosing a Query Shape](#choosing-a-query-shape) below) and the chart unit configuration (see [Unit Handling](#unit-handling) below).
 5. Put the full MPL pipeline in `query.apl` AND set `query.metricsDataset` to the dataset name. Do not set `query.mpl` — the create API rejects it.
 6. **Use `align to $__interval`, not a fixed window.** The dashboard runtime injects `$__interval` based on the time picker and panel width; a fixed `align to 1m` produces broken granularity outside its design range. Do not add `param $__interval: Duration;` to the chart string — the runtime injects it. Pre-validation via `scripts/metrics/metrics-query` requires substituting a concrete duration for that call only.
 7. Validate your query with `scripts/metrics/metrics-query` before embedding in the dashboard.
@@ -66,22 +66,32 @@ When generating metrics chart JSON:
 
 ---
 
+## Choosing a Query Shape
+
+The `metrics-info ... metrics <metric> info` payload returns three fields that should drive how you write the MPL pipeline. **Always read this metadata before composing a query — never assume a metric is a simple scalar.**
+
+| Field | Values | What it tells you |
+|-------|--------|-------------------|
+| `type` | `Gauge`, `CounterMonotonic`, `CounterNonMonotonic`, `Histogram` | The kind of instrument; determines required pre-aggregation operators |
+| `temporality` | `Cumulative`, `Delta`, or `null` | Whether counter values are running totals or per-interval deltas. `null` is normal for Gauges. |
+| `unit` | UCUM-style string (`Cel`, `kW.h`, `s`, `%`, `[ppm]`, …) or `null` | Display unit; preserve when reporting results to the user |
+
+Rules of thumb (consult `metrics-spec` for the exact operator names — they may evolve):
+
+- **Gauge** — instantaneous value. Align directly with `avg`/`min`/`max`/`sum`. Do **not** apply a rate operator; you'd be averaging meaningless deltas of an instantaneous value.
+- **CounterMonotonic + Cumulative** — running total that only goes up (resets aside). The raw values are almost never what the user wants. Convert to a per-second rate first, **then** align/aggregate.
+- **CounterMonotonic + Delta** — already per-interval; can be summed/aligned without a rate step.
+- **CounterNonMonotonic** — can go up or down (e.g. queue depth, balance). Intent is ambiguous: rate, delta, or current value all make sense for different questions. **Ask the user what they want to see** before picking one.
+- **Histogram** — not a scalar. Direct `align using avg` will not give you what you expect. Consult the histogram section of `metrics-spec` for quantile/bucket operators.
+- **`temporality: null`** means "not applicable for this instrument type" (the norm for Gauges), not "missing data".
+
+If a chart combines metrics with mismatched units in a single arithmetic expression, surface a warning in the chart description rather than silently producing a meaningless number.
+
+---
+
 ## Unit Handling
 
-When a metrics chart represents a single metric (typical for **Statistic** panels), surface the metric's unit in the chart configuration so the dashboard formats values correctly. Statistic charts have two slots for this:
-
-- `unit` — an Axiom enum (`TimeSec`, `TimeMS`, `Byte`, `Percent100`, `CurrencyEUR`, …; full list in [chart-config.md](./chart-config.md#available-units)).
-- `customUnits` — a free-form string suffix used when the metric's unit doesn't map to the enum.
-
-**API-level support:** TimeSeries (and Heatmap, Pie, Table, LogStream) accept `customUnits` (free-form suffix string) at the chart top level and round-trip it through GET, but reject the `unit` enum (`Unrecognized key: "unit"` from the create API).
-
-**Statistic charts require both fields to render a suffix.** A Statistic with `unit: "Percent100"` alone renders bare `99.5`; adding `customUnits: "%"` produces `99.5%`. The two fields play different roles — `unit` scales/formats the value, `customUnits` paints the suffix.
-
-Guidance:
-
-- **Statistic with a percentage:** set BOTH `unit: "Percent100"` AND `customUnits: "%"`. The `unit` controls scaling/formatting; `customUnits` is what paints the suffix.
-- **Statistic with bytes/seconds/etc.:** the `unit` enum (e.g. `Byte`, `TimeMS`) abbreviates *and* labels (`1.2 MB`, `350 ms`) on its own. Add `customUnits` only if you want extra trailing text.
-- **TimeSeries / Heatmap / Pie / Table / LogStream:** set `customUnits` if you want — it persists through the API — but **always also encode the unit in the chart `name`** (e.g. `"P95 Latency (ms)"`, `"Memory (MB)"`). The header label is the most reliable unit-labeling mechanism for these chart types. For magnitude conversion, scale in MPL (`| map / 1048576` for bytes → MB, `| map * 100` for ratio → percent).
+Metrics-backed charts should surface the metric's unit in the chart configuration so the dashboard formats values correctly. The chart-level rendering rules (which fields are accepted by which chart type, the Statistic `unit`+`customUnits` pairing, the `Percent` vs `Percent100` trap) are documented once in [chart-config.md § Unit Configuration](./chart-config.md#unit-configuration-cross-chart). This section covers the metrics-specific workflow that translates a metric's UCUM/OTel `unit` metadata into that chart-level configuration.
 
 ### Workflow
 
@@ -99,12 +109,9 @@ Guidance:
    # -> {"unit":"TimeMS"}
 
    scripts/metrics/unit-for "%"
-   # -> {"unit":"Percent100"}
+   # -> {"unit":"Percent100","customUnits":"%"}
    ```
-3. Splice the result into the chart object alongside `name`, `type`, and `query`.
-   - For **Statistic** showing a percentage: set both `unit: "Percent100"` AND `customUnits: "%"` — the enum scales the value, the suffix paints the `%` sign. Without `customUnits` the chart shows bare `99.5`.
-   - For **Statistic** showing bytes/seconds/etc.: set just `unit` (e.g. `Byte`, `TimeMS`); the formatter abbreviates and labels in one step (`1.2 MB`, `350 ms`).
-   - For **TimeSeries / Heatmap / Pie / Table / LogStream**: only `customUnits` is API-accepted (the `unit` enum is rejected). **Always also encode the unit in the chart `name`** (`"P95 Latency (ms)"`, `"Memory (MB)"`) so the header is self-describing. For magnitude conversion, scale in MPL.
+3. Splice the result into the chart object alongside `name`, `type`, and `query`. For **Statistic** the spliced fields render directly. For **TimeSeries / Heatmap / Pie / Table / LogStream** only `customUnits` is API-accepted, so also encode the unit in the chart `name` (e.g. `"P95 Latency (ms)"`) per [chart-config.md § Unit Configuration](./chart-config.md#unit-configuration-cross-chart).
 
 ### Mapping Reference
 
@@ -141,9 +148,7 @@ The following inputs fall through to `customUnits` rather than guessing an enum,
 
 ### Percentages and ratios (OTel 0–1 fractions)
 
-> **⚠️** The Axiom `Percent` enum does **not** auto-multiply 0–1 fractions by 100. A Statistic chart with `"unit": "Percent"` and a metric value of `1.0` (= 100%) renders as the bare string `1`, not `100%`.
-
-OTel and Prometheus emit ratios in `0.0–1.0` (availability, error rate, saturation, cache hit ratio, …). For Axiom Statistic panels you must convert to the 0–100 range that `Percent100` expects, in the **MPL pipeline**:
+OTel and Prometheus emit ratios in `0.0–1.0` (availability, error rate, saturation, cache hit ratio, …). For Axiom charts you must convert to the 0–100 range that `Percent100` expects, in the **MPL pipeline**:
 
 ```mpl
 (
@@ -155,27 +160,7 @@ OTel and Prometheus emit ratios in `0.0–1.0` (availability, error rate, satura
 | align to $__interval using avg
 ```
 
-Then on the chart:
-
-```json
-{ "type": "Statistic", "unit": "Percent100", "customUnits": "%", … }
-```
-
-**Both fields are required to render `99.5%`.** `unit: "Percent100"` alone renders bare `99.5` — the percent enum scales the value but does not paint the `%` suffix. Adding `customUnits: "%"` paints the suffix.
-
-This applies whether the ratio comes from `compute … using /`, from a single metric whose unit metadata is `1`, or from any other 0–1 source. **Never** rely on the `Percent` enum to do the conversion for you, and never rely on `Percent100` alone for the suffix.
-
-For TimeSeries panels, apply the same `| map * 100` to get to the 0–100 scale, and put `"(%)"` in the chart name as the primary unit label. You may also set `customUnits: "%"` for completeness, but treat the chart name as the source of truth for unit labeling on non-Statistic charts.
-
-### When to Use What
-
-| Chart type | What to set | How |
-|---|---|---|
-| Statistic, single metric (bytes/time/currency) | `unit` (enum) | Run `unit-for` on the metric's `unit`; splice into the chart object. The enum abbreviates and labels in one step. |
-| Statistic, computed percentage | `unit: "Percent100"` AND `customUnits: "%"` | Multiply the ratio by 100 in MPL (`| map * 100`), set both fields together. `Percent100` alone does NOT paint the `%` suffix. |
-| Statistic, derived unit not in the enum | `customUnits` only | Set manually — `unit-for` cannot reason about derived units. |
-| TimeSeries | `name` + optional `customUnits` | Encode the unit in the chart name (`"Memory (MB)"`); the `unit` enum is rejected on create. |
-| Heatmap / Pie / Table / LogStream | Same as TimeSeries | Same caveats. |
+This applies whether the ratio comes from `compute … using /`, from a single metric whose unit metadata is `1`, or from any other 0–1 source. The chart-level rendering (which fields to set, why `Percent100` alone is insufficient, why the `Percent` enum is wrong here) is documented in [chart-config.md § Unit Configuration](./chart-config.md#unit-configuration-cross-chart).
 
 ### Mismatched Units Across Metrics
 

--- a/skills/building-dashboards/reference/metrics-mpl.md
+++ b/skills/building-dashboards/reference/metrics-mpl.md
@@ -49,6 +49,8 @@ When generating metrics chart JSON:
 
 > **Note:** `find-metrics <value>` searches tag values, not metric names. Use `metrics-info <deploy> <dataset> metrics` to list metric names.
 
+> **Parameter values:** for manual API calls or pre-validation of a parameterized query, supply values via `scripts/metrics/metrics-query`'s `-p name=value` flag. See the **Passing parameter values** subsection in the `query-metrics` skill for the API contract and request-body shape.
+
 ## Metrics Discovery & Query Scripts
 
 | Script | Usage |

--- a/skills/building-dashboards/reference/metrics-mpl.md
+++ b/skills/building-dashboards/reference/metrics-mpl.md
@@ -1,17 +1,8 @@
 # Metrics/MPL Chart Contract
 
-This reference documents the chart query contract for *metrics-backed* dashboard charts.
+Reference for metrics-backed chart queries. Authoring through `chart-add --mpl '<MPL>' --dataset <name>` handles the JSON-shape rules (sets both `query.apl` and `query.metricsDataset`); the rest of this file covers the **MPL pipeline** and **unit handling** that the agent still owns.
 
-Metrics charts require **two** fields:
-
-- `query.apl` — the MPL pipeline string (same field name used for APL queries).
-- `query.metricsDataset` — the dataset name (e.g. `"otel-metrics"`). This field is what tells the backend to interpret `apl` as MPL. Without it, the chart will not behave correctly even if the pipeline string is well-formed.
-
-Do not send `query.mpl` in create payloads — the create API rejects it even though GET responses for existing metrics dashboards may include it.
-
-> **CRITICAL:** Run `scripts/metrics/metrics-spec <deployment> <dataset>` before composing your first MPL query in a session. NEVER guess MPL syntax.
-
-## Canonical JSON Shape
+## JSON Shape
 
 ```json
 {
@@ -23,75 +14,44 @@ Do not send `query.mpl` in create payloads — the create API rejects it even th
 }
 ```
 
-### Required and Optional Fields
-
-| Field | Required? | Description |
-|-------|-----------|-------------|
-| `apl` | ✅ Yes | The MPL pipeline string. Use this field even for MPL content. |
-| `metricsDataset` | ✅ Yes (for metrics charts) | Dataset name (e.g. `"otel-metrics"`). Denotes the chart as MPL — without it the backend treats `apl` as APL. |
-| `mpl` | ❌ No (rejected) | GET may return it for existing metrics charts, but create rejects it. Put the MPL string in `apl` instead. |
-| `metricsMetric` | ❌ No | UI/editor metadata; not needed for hand-authored create payloads |
-| `metricsFilter` | ❌ No | UI/editor metadata; not needed for hand-authored create payloads |
-| `metricsTransformations` | ❌ No | UI/editor metadata; not needed for hand-authored create payloads |
-
-> **Why both `apl` and `metricsDataset`?** The dashboard create API uses `apl` as the query text field for both APL and MPL queries. `metricsDataset` is the discriminator that flags the chart as MPL. The dataset/metric selector is also embedded in the MPL string itself (e.g. `` `otel-metrics`:`http.server.duration` ``), but `metricsDataset` must still be set explicitly.
+| Field | Required | Notes |
+|---|---|---|
+| `query.apl` | Yes | The MPL pipeline. Same field name as APL queries. |
+| `query.metricsDataset` | Yes | The discriminator that flags MPL. Without it the backend treats `apl` as APL. |
+| `query.mpl` | — | Rejected on create. GET returns it on existing UI-authored charts; ignore. |
+| `query.metricsMetric`, `metricsFilter`, `metricsTransformations` | — | UI/editor metadata. Not needed for hand-authored or `chart-add` output. |
 
 ## Authoring Checklist
 
-When generating metrics chart JSON:
+1. Confirm dataset kind is `otel:metrics:v1`: `scripts/metrics/datasets <deploy>`.
+2. Run `scripts/metrics/metrics-spec <deploy> <dataset>` — required before composing any MPL query.
+3. Discover metrics and tags: `scripts/metrics/metrics-info`. Empty results → retry with `--start` 7 days ago.
+4. Read each metric's `{type, temporality, unit}` via `metrics-info … metrics <m> info`. Drives query shape (below) and unit configuration.
+5. Use `align to $__interval using …`, never a fixed window. The runtime injects `param $__interval: Duration;`; don't add it to the chart string.
+6. Validate the pipeline with `scripts/metrics/mpl-validate-chart` (auto-injects the param for the validator only; rejects inline time ranges).
+7. Pass to `chart-add --mpl '<query>' --dataset <name>`.
 
-1. Confirm dataset kind is `otel:metrics:v1` via `scripts/metrics/datasets <deploy>`.
-2. Run `scripts/metrics/metrics-spec` to learn the full MPL syntax — **mandatory, never guess**.
-3. Discover available metrics and tags with `scripts/metrics/metrics-info`. If results are empty, retry with `--start` set to 7 days ago (sparse metrics may not have data in the default 24h window).
-4. **Read the metric's metadata** with `scripts/metrics/metrics-info <deploy> <dataset> metrics <metric> info`. The returned `{type, temporality, unit}` block drives both the query shape (see [Choosing a Query Shape](#choosing-a-query-shape) below) and the chart unit configuration (see [Unit Handling](#unit-handling) below).
-5. Put the full MPL pipeline in `query.apl` AND set `query.metricsDataset` to the dataset name. Do not set `query.mpl` — the create API rejects it.
-6. **Use `align to $__interval`, not a fixed window.** The dashboard runtime injects `$__interval` based on the time picker and panel width; a fixed `align to 1m` produces broken granularity outside its design range. Do not add `param $__interval: Duration;` to the chart string — the runtime injects it. Pre-validation via `scripts/metrics/metrics-query` requires substituting a concrete duration for that call only.
-7. Validate your query with `scripts/metrics/metrics-query` before embedding in the dashboard.
-
-> **Note:** `find-metrics <value>` searches tag values, not metric names. Use `metrics-info <deploy> <dataset> metrics` to list metric names.
-
-> **Parameter values:** for manual API calls or pre-validation of a parameterized query, supply values via `scripts/metrics/metrics-query`'s `-p name=value` flag. See the **Passing parameter values** subsection in the `query-metrics` skill for the API contract and request-body shape.
-
-## Metrics Discovery & Query Scripts
-
-| Script | Usage |
-|--------|-------|
-| `scripts/metrics/datasets <deploy> [--kind <kind>]` | List datasets (with edge deployment info) |
-| `scripts/metrics/metrics-spec <deploy> <dataset>` | Fetch MPL query specification |
-| `scripts/metrics/metrics-info <deploy> <dataset> ...` | Discover metrics, tags, and values |
-| `scripts/metrics/metrics-query <deploy> <mpl> <start> <end>` | Execute a metrics query |
-| `scripts/metrics/unit-for <unit-string>` | Map a UCUM/OTel unit to an Axiom chart unit config |
-
-> The `datasets`, `metrics-spec`, `metrics-info`, and `metrics-query` scripts are vendored from `query-metrics`. Keep in sync if upstream behavior changes. `unit-for` is dashboard-specific and lives only here.
-
----
+`find-metrics <value>` searches tag *values*, not metric names — only useful with a known entity name.
 
 ## Choosing a Query Shape
 
-The `metrics-info ... metrics <metric> info` payload returns three fields that should drive how you write the MPL pipeline. **Always read this metadata before composing a query — never assume a metric is a simple scalar.**
+The `{type, temporality, unit}` block from `metrics-info` drives the pipeline:
 
-| Field | Values | What it tells you |
-|-------|--------|-------------------|
-| `type` | `Gauge`, `CounterMonotonic`, `CounterNonMonotonic`, `Histogram` | The kind of instrument; determines required pre-aggregation operators |
-| `temporality` | `Cumulative`, `Delta`, or `null` | Whether counter values are running totals or per-interval deltas. `null` is normal for Gauges. |
-| `unit` | UCUM-style string (`Cel`, `kW.h`, `s`, `%`, `[ppm]`, …) or `null` | Display unit; preserve when reporting results to the user |
+| `type` | `temporality` | Pipeline |
+|---|---|---|
+| `Gauge` | `null` | Align directly with `avg`/`min`/`max`/`sum`. No rate. |
+| `CounterMonotonic` | `Cumulative` | Convert to per-second rate (`align using prom::rate`), then aggregate. |
+| `CounterMonotonic` | `Delta` | Already per-interval. Sum/align directly. |
+| `CounterNonMonotonic` | either | Ambiguous (rate? delta? current value?). Ask the user. |
+| `Histogram` | either | Use `bucket … using interpolate_cumulative_histogram` (cumulative) or `interpolate_delta_histogram` (delta). Plain `align using avg` produces nonsense. |
 
-Rules of thumb (consult `metrics-spec` for the exact operator names — they may evolve):
+`temporality: null` means "not applicable" (the norm for Gauges), not "missing data".
 
-- **Gauge** — instantaneous value. Align directly with `avg`/`min`/`max`/`sum`. Do **not** apply a rate operator; you'd be averaging meaningless deltas of an instantaneous value.
-- **CounterMonotonic + Cumulative** — running total that only goes up (resets aside). The raw values are almost never what the user wants. Convert to a per-second rate first, **then** align/aggregate.
-- **CounterMonotonic + Delta** — already per-interval; can be summed/aligned without a rate step.
-- **CounterNonMonotonic** — can go up or down (e.g. queue depth, balance). Intent is ambiguous: rate, delta, or current value all make sense for different questions. **Ask the user what they want to see** before picking one.
-- **Histogram** — not a scalar. Direct `align using avg` will not give you what you expect. Consult the histogram section of `metrics-spec` for quantile/bucket operators.
-- **`temporality: null`** means "not applicable for this instrument type" (the norm for Gauges), not "missing data".
-
-If a chart combines metrics with mismatched units in a single arithmetic expression, surface a warning in the chart description rather than silently producing a meaningless number.
-
----
+If a chart combines metrics with mismatched units in arithmetic, surface the units in the chart description; `unit-for` doesn't infer derived units.
 
 ## Unit Handling
 
-Metrics-backed charts should surface the metric's unit in the chart configuration so the dashboard formats values correctly. The chart-level rendering rules (which fields are accepted by which chart type, the Statistic `unit`+`customUnits` pairing, the `Percent` vs `Percent100` trap) are documented once in [chart-config.md § Unit Configuration](./chart-config.md#unit-configuration-cross-chart). This section covers the metrics-specific workflow that translates a metric's UCUM/OTel `unit` metadata into that chart-level configuration.
+`chart-add --unit` accepts a friendly string and maps via `scripts/metrics/unit-for` (same script does the OTel → Axiom enum translation on its own). The chart-level rendering rules — which fields each chart kind accepts, the `Percent`/`Percent100` trap — live in [`chart-config.md`](./chart-config.md). This section covers the metrics-specific path.
 
 ### Workflow
 
@@ -100,55 +60,35 @@ Metrics-backed charts should surface the metric's unit in the chart configuratio
    scripts/metrics/metrics-info <deploy> <dataset> metrics <metric> info
    # -> {"type":"Gauge","temporality":null,"unit":"Cel"}
    ```
-2. Map the `unit` to a chart unit config:
+2. Map (or pass through to `chart-add --unit`):
    ```bash
-   scripts/metrics/unit-for "Cel"
-   # -> {"unit":"Auto","customUnits":"Cel"}
-
-   scripts/metrics/unit-for "ms"
-   # -> {"unit":"TimeMS"}
-
-   scripts/metrics/unit-for "%"
-   # -> {"unit":"Percent100","customUnits":"%"}
+   scripts/metrics/unit-for "Cel"   # -> {"unit":"Auto","customUnits":"Cel"}
+   scripts/metrics/unit-for "ms"    # -> {"unit":"TimeMS"}
+   scripts/metrics/unit-for "%"     # -> {"unit":"Percent100","customUnits":"%"}
    ```
-3. Splice the result into the chart object alongside `name`, `type`, and `query`. For **Statistic** the spliced fields render directly. For **TimeSeries / Heatmap / Pie / Table / LogStream** only `customUnits` is API-accepted, so also encode the unit in the chart `name` (e.g. `"P95 Latency (ms)"`) per [chart-config.md § Unit Configuration](./chart-config.md#unit-configuration-cross-chart).
+3. For `Statistic`, `chart-add --unit` writes both fields. For other chart types, only `customUnits` — also encode the unit in `--name` (`"P95 Latency (ms)"`).
 
-### Mapping Reference
+### Mapping reference
 
-`unit-for` recognizes these UCUM/OTel codes and emits an Axiom enum value; everything else falls through to `{"unit":"Auto","customUnits":"<verbatim>"}`:
+`unit-for` recognises these UCUM/OTel codes; everything else falls through to `customUnits`:
 
-| Incoming unit | Axiom enum |
+| Input | Axiom enum |
 |---|---|
 | `s`, `seconds`, `sec` | `TimeSec` |
 | `ms`, `milliseconds` | `TimeMS` |
 | `us`, `µs`, `microseconds` | `TimeUS` |
 | `ns`, `nanoseconds` | `TimeNS` |
-| `min` | `TimeMin` |
-| `h`, `hour`, `hours` | `TimeHour` |
-| `d`, `day`, `days` | `TimeDay` |
-| `By`, `bytes` | `Byte` |
-| `KBy`, `KiBy` | `Kilobyte` |
-| `MBy`, `MiBy` | `Megabyte` |
-| `GBy`, `GiBy` | `Gigabyte` |
-| `By/s`, `bytes/s` | `BytesSec` |
-| `bit/s` | `BitsSec` |
-| `%` | `Percent100` |
-| `USD`, `EUR`, `GBP`, `JPY`, `INR`, `CAD`, `AUD`, `CZK`, `PLN` | `Currency<XXX>` |
+| `min`, `h`, `hour`, `d`, `day` | `TimeMin`/`TimeHour`/`TimeDay` |
+| `By`, `bytes`, `KBy`/`MBy`/`GBy` | `Byte`/`Kilobyte`/`Megabyte`/`Gigabyte` |
+| `By/s`, `bit/s` | `BytesSec`/`BitsSec` |
+| `%` | `Percent100` (+ `customUnits: "%"`) |
+| `USD`/`EUR`/`GBP`/`JPY`/`INR`/`CAD`/`AUD`/`CZK`/`PLN` | `Currency<XXX>` |
 
-### Deliberately Not Auto-Mapped
-
-The following inputs fall through to `customUnits` rather than guessing an enum, because the UCUM code is ambiguous or context-dependent. The chart author can override manually if they know the intent.
-
-| Input | Why not auto-mapped |
-|---|---|
-| `m`   | Could mean metres or minutes (UCUM uses `min` for the latter, but `m` is loose in the wild). |
-| `B`   | UCUM `B` is Bel; bytes are `By`. Avoids silently treating decibels as bytes. |
-| `1`   | OTel "dimensionless" sentinel. Could be a 0–1 ratio or a unitless count. Defaults to `Auto` with no suffix. **If it's a 0–1 ratio, do NOT use the `Percent` enum** — see the percentage handling note below. |
-| `""` (empty) / null | No unit information; defaults to `Auto`. |
+Deliberately not auto-mapped (ambiguous): `m` (metres or minutes), `B` (Bel — bytes are `By`), `1` (OTel "dimensionless" — could be ratio or count), empty/null. These fall through to `customUnits` verbatim or `Auto`.
 
 ### Percentages and ratios (OTel 0–1 fractions)
 
-OTel and Prometheus emit ratios in `0.0–1.0` (availability, error rate, saturation, cache hit ratio, …). For Axiom charts you must convert to the 0–100 range that `Percent100` expects, in the **MPL pipeline**:
+OTel ratios (availability, error rate, saturation, hit ratio) are emitted as 0–1 fractions. `Percent100` does NOT auto-multiply — convert in MPL:
 
 ```mpl
 (
@@ -156,12 +96,8 @@ OTel and Prometheus emit ratios in `0.0–1.0` (availability, error rate, satura
   `<dataset>`:requests_total                          | map rate | group using sum
 )
 | compute availability using /
-| map * 100                       // <-- mandatory: convert fraction → percentage
+| map * 100
 | align to $__interval using avg
 ```
 
-This applies whether the ratio comes from `compute … using /`, from a single metric whose unit metadata is `1`, or from any other 0–1 source. The chart-level rendering (which fields to set, why `Percent100` alone is insufficient, why the `Percent` enum is wrong here) is documented in [chart-config.md § Unit Configuration](./chart-config.md#unit-configuration-cross-chart).
-
-### Mismatched Units Across Metrics
-
-If a chart combines multiple metrics in arithmetic (e.g. `metric_a / metric_b`) and their `unit` values differ, the result's unit is the chart author's responsibility. `unit-for` does not attempt to infer derived units. Surface the source units in the chart description so reviewers can sanity-check the math.
+Then pass `chart-add --unit "%"`.

--- a/skills/building-dashboards/reference/metrics-mpl.md
+++ b/skills/building-dashboards/reference/metrics-mpl.md
@@ -43,9 +43,10 @@ When generating metrics chart JSON:
 1. Confirm dataset kind is `otel:metrics:v1` via `scripts/metrics/datasets <deploy>`.
 2. Run `scripts/metrics/metrics-spec` to learn the full MPL syntax — **mandatory, never guess**.
 3. Discover available metrics and tags with `scripts/metrics/metrics-info`. If results are empty, retry with `--start` set to 7 days ago (sparse metrics may not have data in the default 24h window).
-4. Put the full MPL pipeline in `query.apl` AND set `query.metricsDataset` to the dataset name. Do not set `query.mpl` — the create API rejects it.
-5. **Use `align to $__interval`, not a fixed window.** The dashboard runtime injects `$__interval` based on the time picker and panel width; a fixed `align to 1m` produces broken granularity outside its design range. Do not add `param $__interval: Duration;` to the chart string — the runtime injects it. Pre-validation via `scripts/metrics/metrics-query` requires substituting a concrete duration for that call only.
-6. Validate your query with `scripts/metrics/metrics-query` before embedding in the dashboard.
+4. **Read the metric's metadata** with `scripts/metrics/metrics-info <deploy> <dataset> metrics <metric> info`. The returned `{type, temporality, unit}` block drives both the query shape (see the `query-metrics` skill's "Choosing a query shape from metric metadata" section) and the chart unit configuration (see [Unit Handling](#unit-handling) below).
+5. Put the full MPL pipeline in `query.apl` AND set `query.metricsDataset` to the dataset name. Do not set `query.mpl` — the create API rejects it.
+6. **Use `align to $__interval`, not a fixed window.** The dashboard runtime injects `$__interval` based on the time picker and panel width; a fixed `align to 1m` produces broken granularity outside its design range. Do not add `param $__interval: Duration;` to the chart string — the runtime injects it. Pre-validation via `scripts/metrics/metrics-query` requires substituting a concrete duration for that call only.
+7. Validate your query with `scripts/metrics/metrics-query` before embedding in the dashboard.
 
 > **Note:** `find-metrics <value>` searches tag values, not metric names. Use `metrics-info <deploy> <dataset> metrics` to list metric names.
 
@@ -59,5 +60,123 @@ When generating metrics chart JSON:
 | `scripts/metrics/metrics-spec <deploy> <dataset>` | Fetch MPL query specification |
 | `scripts/metrics/metrics-info <deploy> <dataset> ...` | Discover metrics, tags, and values |
 | `scripts/metrics/metrics-query <deploy> <mpl> <start> <end>` | Execute a metrics query |
+| `scripts/metrics/unit-for <unit-string>` | Map a UCUM/OTel unit to an Axiom chart unit config |
 
-> These scripts are vendored from `query-metrics`. Keep in sync if upstream behavior changes.
+> The `datasets`, `metrics-spec`, `metrics-info`, and `metrics-query` scripts are vendored from `query-metrics`. Keep in sync if upstream behavior changes. `unit-for` is dashboard-specific and lives only here.
+
+---
+
+## Unit Handling
+
+When a metrics chart represents a single metric (typical for **Statistic** panels), surface the metric's unit in the chart configuration so the dashboard formats values correctly. Statistic charts have two slots for this:
+
+- `unit` — an Axiom enum (`TimeSec`, `TimeMS`, `Byte`, `Percent100`, `CurrencyEUR`, …; full list in [chart-config.md](./chart-config.md#available-units)).
+- `customUnits` — a free-form string suffix used when the metric's unit doesn't map to the enum.
+
+**API-level support:** TimeSeries (and Heatmap, Pie, Table, LogStream) accept `customUnits` (free-form suffix string) at the chart top level and round-trip it through GET, but reject the `unit` enum (`Unrecognized key: "unit"` from the create API).
+
+**Statistic charts require both fields to render a suffix.** A Statistic with `unit: "Percent100"` alone renders bare `99.5`; adding `customUnits: "%"` produces `99.5%`. The two fields play different roles — `unit` scales/formats the value, `customUnits` paints the suffix.
+
+Guidance:
+
+- **Statistic with a percentage:** set BOTH `unit: "Percent100"` AND `customUnits: "%"`. The `unit` controls scaling/formatting; `customUnits` is what paints the suffix.
+- **Statistic with bytes/seconds/etc.:** the `unit` enum (e.g. `Byte`, `TimeMS`) abbreviates *and* labels (`1.2 MB`, `350 ms`) on its own. Add `customUnits` only if you want extra trailing text.
+- **TimeSeries / Heatmap / Pie / Table / LogStream:** set `customUnits` if you want — it persists through the API — but **always also encode the unit in the chart `name`** (e.g. `"P95 Latency (ms)"`, `"Memory (MB)"`). The header label is the most reliable unit-labeling mechanism for these chart types. For magnitude conversion, scale in MPL (`| map / 1048576` for bytes → MB, `| map * 100` for ratio → percent).
+
+### Workflow
+
+1. Fetch the metric's metadata:
+   ```bash
+   scripts/metrics/metrics-info <deploy> <dataset> metrics <metric> info
+   # -> {"type":"Gauge","temporality":null,"unit":"Cel"}
+   ```
+2. Map the `unit` to a chart unit config:
+   ```bash
+   scripts/metrics/unit-for "Cel"
+   # -> {"unit":"Auto","customUnits":"Cel"}
+
+   scripts/metrics/unit-for "ms"
+   # -> {"unit":"TimeMS"}
+
+   scripts/metrics/unit-for "%"
+   # -> {"unit":"Percent100"}
+   ```
+3. Splice the result into the chart object alongside `name`, `type`, and `query`.
+   - For **Statistic** showing a percentage: set both `unit: "Percent100"` AND `customUnits: "%"` — the enum scales the value, the suffix paints the `%` sign. Without `customUnits` the chart shows bare `99.5`.
+   - For **Statistic** showing bytes/seconds/etc.: set just `unit` (e.g. `Byte`, `TimeMS`); the formatter abbreviates and labels in one step (`1.2 MB`, `350 ms`).
+   - For **TimeSeries / Heatmap / Pie / Table / LogStream**: only `customUnits` is API-accepted (the `unit` enum is rejected). **Always also encode the unit in the chart `name`** (`"P95 Latency (ms)"`, `"Memory (MB)"`) so the header is self-describing. For magnitude conversion, scale in MPL.
+
+### Mapping Reference
+
+`unit-for` recognizes these UCUM/OTel codes and emits an Axiom enum value; everything else falls through to `{"unit":"Auto","customUnits":"<verbatim>"}`:
+
+| Incoming unit | Axiom enum |
+|---|---|
+| `s`, `seconds`, `sec` | `TimeSec` |
+| `ms`, `milliseconds` | `TimeMS` |
+| `us`, `µs`, `microseconds` | `TimeUS` |
+| `ns`, `nanoseconds` | `TimeNS` |
+| `min` | `TimeMin` |
+| `h`, `hour`, `hours` | `TimeHour` |
+| `d`, `day`, `days` | `TimeDay` |
+| `By`, `bytes` | `Byte` |
+| `KBy`, `KiBy` | `Kilobyte` |
+| `MBy`, `MiBy` | `Megabyte` |
+| `GBy`, `GiBy` | `Gigabyte` |
+| `By/s`, `bytes/s` | `BytesSec` |
+| `bit/s` | `BitsSec` |
+| `%` | `Percent100` |
+| `USD`, `EUR`, `GBP`, `JPY`, `INR`, `CAD`, `AUD`, `CZK`, `PLN` | `Currency<XXX>` |
+
+### Deliberately Not Auto-Mapped
+
+The following inputs fall through to `customUnits` rather than guessing an enum, because the UCUM code is ambiguous or context-dependent. The chart author can override manually if they know the intent.
+
+| Input | Why not auto-mapped |
+|---|---|
+| `m`   | Could mean metres or minutes (UCUM uses `min` for the latter, but `m` is loose in the wild). |
+| `B`   | UCUM `B` is Bel; bytes are `By`. Avoids silently treating decibels as bytes. |
+| `1`   | OTel "dimensionless" sentinel. Could be a 0–1 ratio or a unitless count. Defaults to `Auto` with no suffix. **If it's a 0–1 ratio, do NOT use the `Percent` enum** — see the percentage handling note below. |
+| `""` (empty) / null | No unit information; defaults to `Auto`. |
+
+### Percentages and ratios (OTel 0–1 fractions)
+
+> **⚠️** The Axiom `Percent` enum does **not** auto-multiply 0–1 fractions by 100. A Statistic chart with `"unit": "Percent"` and a metric value of `1.0` (= 100%) renders as the bare string `1`, not `100%`.
+
+OTel and Prometheus emit ratios in `0.0–1.0` (availability, error rate, saturation, cache hit ratio, …). For Axiom Statistic panels you must convert to the 0–100 range that `Percent100` expects, in the **MPL pipeline**:
+
+```mpl
+(
+  `<dataset>`:requests_total | where code != #/5../ | map rate | group using sum,
+  `<dataset>`:requests_total                          | map rate | group using sum
+)
+| compute availability using /
+| map * 100                       // <-- mandatory: convert fraction → percentage
+| align to $__interval using avg
+```
+
+Then on the chart:
+
+```json
+{ "type": "Statistic", "unit": "Percent100", "customUnits": "%", … }
+```
+
+**Both fields are required to render `99.5%`.** `unit: "Percent100"` alone renders bare `99.5` — the percent enum scales the value but does not paint the `%` suffix. Adding `customUnits: "%"` paints the suffix.
+
+This applies whether the ratio comes from `compute … using /`, from a single metric whose unit metadata is `1`, or from any other 0–1 source. **Never** rely on the `Percent` enum to do the conversion for you, and never rely on `Percent100` alone for the suffix.
+
+For TimeSeries panels, apply the same `| map * 100` to get to the 0–100 scale, and put `"(%)"` in the chart name as the primary unit label. You may also set `customUnits: "%"` for completeness, but treat the chart name as the source of truth for unit labeling on non-Statistic charts.
+
+### When to Use What
+
+| Chart type | What to set | How |
+|---|---|---|
+| Statistic, single metric (bytes/time/currency) | `unit` (enum) | Run `unit-for` on the metric's `unit`; splice into the chart object. The enum abbreviates and labels in one step. |
+| Statistic, computed percentage | `unit: "Percent100"` AND `customUnits: "%"` | Multiply the ratio by 100 in MPL (`| map * 100`), set both fields together. `Percent100` alone does NOT paint the `%` suffix. |
+| Statistic, derived unit not in the enum | `customUnits` only | Set manually — `unit-for` cannot reason about derived units. |
+| TimeSeries | `name` + optional `customUnits` | Encode the unit in the chart name (`"Memory (MB)"`); the `unit` enum is rejected on create. |
+| Heatmap / Pie / Table / LogStream | Same as TimeSeries | Same caveats. |
+
+### Mismatched Units Across Metrics
+
+If a chart combines multiple metrics in arithmetic (e.g. `metric_a / metric_b`) and their `unit` values differ, the result's unit is the chart author's responsibility. `unit-for` does not attempt to infer derived units. Surface the source units in the chart description so reviewers can sanity-check the math.

--- a/skills/building-dashboards/reference/promql-to-mpl.md
+++ b/skills/building-dashboards/reference/promql-to-mpl.md
@@ -1,13 +1,13 @@
 # PromQL → MPL Translation
 
-How to translate a PromQL expression into an Axiom MPL pipeline without losing structure. The translation rules are mechanical; the source PromQL carries the spec.
+Mechanical translation rules. The source PromQL carries the spec — translate, don't reinvent.
 
-> **Two rules govern this whole document:**
->
-> 1. **Mechanical preservation.** Every PromQL `{label="x"}` selector becomes an MPL `where` clause. Every PromQL `by(label1, label2)` dimension becomes an MPL `group by`. Never drop one because the metric name "feels" scoped to it — the selector or grouping was a deliberate authoring choice, not decoration.
-> 2. **Reverse-tag discovery for name mismatches.** When a PromQL label name does not exist verbatim in the MPL dataset, **do not drop the selector**. Apply the OTel ingest rename rules first, then use `scripts/metrics/metrics-info` to find the equivalent tag, then map. Discovery is a validator, never a generator.
+**Two rules:**
 
-This doc covers translation, not MPL syntax. Run `scripts/metrics/metrics-spec <deploy> <dataset>` before authoring to fetch the live spec for the target deployment — operator names and availability evolve, and the spec is the only source of truth. The translation rules below assume you've done that.
+1. **Preserve structure.** Every `{label="x"}` selector → MPL `where`. Every `by(label1, label2)` → MPL `group by`. Never drop one because the metric "feels" scoped to it.
+2. **Reverse-tag discovery for missing labels.** Apply OTel rename rules first, then use `metrics-info` to find the equivalent tag. Discovery is a validator, not a generator.
+
+Run `scripts/metrics/metrics-spec <deploy> <dataset>` before authoring — operator names evolve and the spec is the source of truth.
 
 ---
 
@@ -31,29 +31,20 @@ Full rules and order of operations are in [grafana-migration.md § Name Mapping]
 
 Every label matcher in the PromQL `{…}` becomes a `where` clause on the MPL pipeline. Multiple matchers are conjunctive in PromQL and translate to a chain of `where` clauses (also conjunctive) — or one `where` with `and`.
 
-> **Fetch the tag type before translating.** PromQL stores every label as a string, so its only comparison operators are equality (`=`, `!=`) and regex (`=~`, `!~`). MPL has typed tags — string, int, float, bool — and supports typed comparisons (`==`, `!=`, `<`, `<=`, `>`, `>=`) on numeric and bool tags. **The right MPL operator depends on the tag's type in the dataset, not on what PromQL did with it.**
->
-> **The authoritative type check is MPL's `<tag> is <type>` operator** (run via `metrics-query`):
->
-> ```bash
-> scripts/metrics/metrics-query <deploy> '`<dataset>`:`<metric>` | filter `<tag>` is int | align to 5m using sum' now-1h now
-> ```
->
-> Non-empty `series` in the response means the tag is `int`-typed for that metric. Run the probe for `int`, `float`, `string`, `bool` as needed; the type that returns series is the type the dataset stores. Type can vary across datasets — Prometheus-imported data tends to stringify everything (even values that look numeric or boolean), OTel-native ingest preserves types — so probe per dataset, never assume.
->
-> **The `tags/<tag>/values` endpoint is a hint, not a determination:**
->
-> ```bash
-> scripts/metrics/metrics-info <deploy> <dataset> tags <tag> values
-> ```
->
-> Unquoted numbers in the JSON response strongly suggest numeric typing. Uniformly quoted values are **inconclusive** — could be a string-typed tag, a numeric tag stringified at ingest, or a float tag with `+Inf`/`NaN` rendered as JSON strings (JSON has no infinity literal even though MPL types these as `float`). Use the values list to pick candidate types, then confirm with the `is <type>` probe.
->
-> **For tags with inconsistent type across rows,** use the defensive form (from the `/v1/query/_mpl` OPTIONS spec):
->
-> ```mpl
-> | filter (`tag` is int and `tag` == 200) or (`tag` is string and `tag` == "200")
-> ```
+**Fetch the tag type before translating.** PromQL stores every label as a string; MPL has typed tags (string/int/float/bool) and the right operator depends on the dataset's type, not on what PromQL did:
+
+```bash
+scripts/metrics/metrics-info <deploy> <dataset> metrics <metric> tags <tag> type
+# -> {"type": "int", "present_types": ["int"]}
+```
+
+Don't infer from `metrics-info … tags <tag> values` alone — Prometheus-imported tags often stringify numerics; quoted values in JSON are inconclusive. The probe runs `filter <tag> is <T>` for each candidate type and reports which return non-empty series.
+
+If `type` comes back `"mixed"`, the tag carries multiple types across rows. Use the defensive form:
+
+```mpl
+| filter (`tag` is int and `tag` == 200) or (`tag` is string and `tag` == "200")
+```
 
 ### Translation by tag type
 
@@ -91,13 +82,15 @@ http_request_duration_seconds_count{
 }
 ```
 
-Probe each tag's type before authoring (per the type-fetch rule above):
+Probe each tag's type before authoring:
 
 ```bash
-scripts/metrics/metrics-query test '`test`:`http_request_duration_seconds_count` | filter `code` is int | align to 5m using sum' now-1h now
+scripts/metrics/metrics-info test test http_request_duration_seconds_count tags code type
+scripts/metrics/metrics-info test test http_request_duration_seconds_count tags container type
+scripts/metrics/metrics-info test test http_request_duration_seconds_count tags path type
 ```
 
-Non-empty result confirms `code` is `int`-typed. Repeat for `container` and `path` with `is string`. If `code` came back empty for `is int` and non-empty for `is string`, the dataset stores `code` as a string and you'd translate the regex form instead (`| where code == #/[5-9]../`) — see the string-typed table above.
+If `code` comes back `"int"`, use the typed-comparison form below. If it comes back `"string"`, translate the regex instead (`| where code == #/[5-9]../`) — see the string-typed table above.
 
 In MPL, with `container` and `path` confirmed as strings and `code` confirmed as int:
 
@@ -147,7 +140,7 @@ test:http_requests_total
 
 ### `by(...)` is mandatory to preserve
 
-The single most common F3 failure: dropping a dimension from `by(...)` because the metric name "feels" scoped to one of them. Never do this — the dimension was specified for a reason. Drop one and the resulting chart has the wrong shape.
+Most common translation bug: dropping a `by(...)` dimension because the metric "feels" scoped to one. Never do this — the dimension was specified deliberately. Drop one and the chart has the wrong shape.
 
 ```promql
 sum by (instance, name) (workqueue_depth)   // two dimensions, both required
@@ -229,7 +222,7 @@ sum(rate(http_requests_total[5m]))
 **Two notes for translators:**
 
 1. **Both branches must have the same shape** — same `align` window, same grouping. If one has `group by service` and the other doesn't, the join will not line up.
-2. **Ratios are 0–1 fractions, not percentages.** If the chart is a Statistic with `unit: "Percent100"`, multiply by 100 in MPL before deploying: `| map * 100`. See [chart-config.md § Unit Configuration](./chart-config.md#unit-configuration-cross-chart) and [metrics-mpl.md § Percentages and ratios](./metrics-mpl.md#percentages-and-ratios-otel-01-fractions).
+2. **Ratios are 0–1 fractions, not percentages.** Multiply by 100 in MPL before passing to `chart-add --unit "%"`: `| map * 100`. See [metrics-mpl.md § Percentages and ratios](./metrics-mpl.md#percentages-and-ratios-otel-01-fractions).
 
 For naming a branch in `compute`, use the `as` keyword: `test:http_requests_total as failure`. Helpful when the same metric appears twice with different filters.
 
@@ -269,18 +262,18 @@ Discovery validates that the spec'd subset exists in the dataset. It **does not*
 
 ---
 
-## Selector Values Not in the Dataset Are Aliases — Cite the Source
+## Selector Values Absent from the Dataset Are Aliases — Cite the Source
 
-When a PromQL selector value is **absent** from the dataset's tag values, the value is a recording-rule alias or other shorthand defined elsewhere — not a literal value to translate. Shape of the case: PromQL has `{<label>="<alias>"}`, but `metrics-info … tags <label> values` returns a set that does not include `"<alias>"`. The alias resolves to some subset `{A, B, …}` of the values that *are* in the dataset, but the subset is defined outside the dashboard JSON.
+When a PromQL selector value isn't in `metrics-info … tags <label> values`, the value is a recording-rule alias defined elsewhere, not a literal to translate. The alias expands to a subset of the dataset's values — but that subset is defined *outside* the dashboard JSON.
 
-Resolve the alias by citing a **written source**:
+Resolve by citing a **written source**:
 
-- the panel's `description` field (often enumerates the subset in prose), **or**
-- the upstream rule library file and line (e.g. `<rule-library>.<ext>:L<n>`).
+- the panel's `description` field (often enumerates the subset in prose), or
+- the upstream rule library file + line (e.g. `<rule-library>.<ext>:L<n>`).
 
-**Memory is not a source.** Prior knowledge of an upstream rule library is unreliable — agents recall the *shape* of definitions more confidently than they recall the exact contents, and rule libraries get edited over time. The failure mode on file: an agent expanded an alias from memory instead of opening either the panel `description` or the upstream rule definition; both written sources agreed on the subset, the agent's recall matched neither, and the deployed panel filtered a different subset than the source dashboard. The fix is procedural: **no expansion of an alias may be attributed to general knowledge — produce a citation, or defer the panel with a Note.**
+**Memory is not a source.** Agents recall the *shape* of rule definitions more confidently than the exact contents, and rule libraries change over time. No citation → defer the panel with a Note.
 
-Detection trigger: `metrics-info <deploy> <dataset> tags <label> values` does not contain the value the PromQL selector expects. That absence is the cue that an alias is in play; from that moment forward, prior-knowledge expansion is forbidden.
+Detection trigger: the value isn't in `metrics-info … tags <label> values`. From that point on, no prior-knowledge expansion is allowed.
 
 ---
 

--- a/skills/building-dashboards/reference/promql-to-mpl.md
+++ b/skills/building-dashboards/reference/promql-to-mpl.md
@@ -1,0 +1,303 @@
+# PromQL → MPL Translation
+
+How to translate a PromQL expression into an Axiom MPL pipeline without losing structure. The translation rules are mechanical; the source PromQL carries the spec.
+
+> **Two rules govern this whole document:**
+>
+> 1. **Mechanical preservation.** Every PromQL `{label="x"}` selector becomes an MPL `where` clause. Every PromQL `by(label1, label2)` dimension becomes an MPL `group by`. Never drop one because the metric name "feels" scoped to it — the selector or grouping was a deliberate authoring choice, not decoration.
+> 2. **Reverse-tag discovery for name mismatches.** When a PromQL label name does not exist verbatim in the MPL dataset, **do not drop the selector**. Apply the OTel ingest rename rules first, then use `scripts/metrics/metrics-info` to find the equivalent tag, then map. Discovery is a validator, never a generator.
+
+This doc covers translation, not MPL syntax. Run `scripts/metrics/metrics-spec <deploy> <dataset>` before authoring to fetch the live spec for the target deployment — operator names and availability evolve, and the spec is the only source of truth. The translation rules below assume you've done that.
+
+---
+
+## Pre-translation: Name shape
+
+Before reaching for `metrics-info`, apply the deterministic Prometheus → OTel renaming rules. Most "missing metric" cases dissolve at this step.
+
+| PromQL form                                                    | OTel form                              |
+|:---------------------------------------------------------------|:---------------------------------------|
+| `<metric>_total` (counter)                                     | `<metric>` (counter-ness in metadata)  |
+| `<metric>_bucket` / `<metric>_sum` / `<metric>_count` (histogram derivatives) | `<metric>` (one Histogram metric) |
+| `<metric>_seconds`, `<metric>_bytes`, `<metric>_milliseconds`  | sometimes preserved; sometimes only in `unit` metadata |
+
+**Label names are not deterministic.** Prometheus label names do not round-trip cleanly to OTel attribute names — the OTel→Prom direction (dots in OTel attributes become underscores in Prom) is convention, but the reverse is a guess. A Prom label like `job` is *not* a renamed OTel attribute; a Prom label like `service_name` *might* be the OTel attribute `service.name`, or it might just be a Prom label called `service_name`. Treat label-name resolution as reverse-tag-discovery work (see below), not as a deterministic renaming step.
+
+Full rules and order of operations are in [grafana-migration.md § Name Mapping](./grafana-migration.md#name-mapping-promql--otel-ingest).
+
+---
+
+## Selector translation: PromQL `{…}` → MPL `where`
+
+Every label matcher in the PromQL `{…}` becomes a `where` clause on the MPL pipeline. Multiple matchers are conjunctive in PromQL and translate to a chain of `where` clauses (also conjunctive) — or one `where` with `and`.
+
+> **Fetch the tag type before translating.** PromQL stores every label as a string, so its only comparison operators are equality (`=`, `!=`) and regex (`=~`, `!~`). MPL has typed tags — string, int, float, bool — and supports typed comparisons (`==`, `!=`, `<`, `<=`, `>`, `>=`) on numeric and bool tags. **The right MPL operator depends on the tag's type in the dataset, not on what PromQL did with it.**
+>
+> **The authoritative type check is MPL's `<tag> is <type>` operator** (run via `metrics-query`):
+>
+> ```bash
+> scripts/metrics/metrics-query <deploy> '`<dataset>`:`<metric>` | filter `<tag>` is int | align to 5m using sum' now-1h now
+> ```
+>
+> Non-empty `series` in the response means the tag is `int`-typed for that metric. Run the probe for `int`, `float`, `string`, `bool` as needed; the type that returns series is the type the dataset stores. Type can vary across datasets — Prometheus-imported data tends to stringify everything (even values that look numeric or boolean), OTel-native ingest preserves types — so probe per dataset, never assume.
+>
+> **The `tags/<tag>/values` endpoint is a hint, not a determination:**
+>
+> ```bash
+> scripts/metrics/metrics-info <deploy> <dataset> tags <tag> values
+> ```
+>
+> Unquoted numbers in the JSON response strongly suggest numeric typing. Uniformly quoted values are **inconclusive** — could be a string-typed tag, a numeric tag stringified at ingest, or a float tag with `+Inf`/`NaN` rendered as JSON strings (JSON has no infinity literal even though MPL types these as `float`). Use the values list to pick candidate types, then confirm with the `is <type>` probe.
+>
+> **For tags with inconsistent type across rows,** use the defensive form (from the `/v1/query/_mpl` OPTIONS spec):
+>
+> ```mpl
+> | filter (`tag` is int and `tag` == 200) or (`tag` is string and `tag` == "200")
+> ```
+
+### Translation by tag type
+
+**String-typed tag** (most labels — `service.name`, `path`, `container`, etc.):
+
+| PromQL matcher              | MPL `where` form                              |
+|:----------------------------|:----------------------------------------------|
+| `{label="value"}`           | `\| where label == "value"`                    |
+| `{label!="value"}`          | `\| where label != "value"`                    |
+| `{label=~"regex"}`          | `\| where label == #/regex/`                   |
+| `{label!~"regex"}`          | `\| where label != #/regex/`                   |
+
+MPL regex uses `#/…/` delimiters (no quotes). Forward slashes inside the pattern need escaping (`\/`).
+
+**Numeric-typed tag** (`int` or `float` — common for HTTP status codes, ports, queue depths):
+
+PromQL stored the value as a string and used regex to match ranges (`code=~"5.."`). When the same tag is `int`-typed in MPL, **translate to a typed comparison** — it's faster, clearer, and matches the user's intent.
+
+| PromQL                       | MPL (when `code` is `int`)                  |
+|:-----------------------------|:--------------------------------------------|
+| `{code="500"}`               | `\| where code == 500`                       |
+| `{code=~"5.."}`              | `\| where code >= 500 and code < 600`        |
+| `{code!~"[1234].."}`         | `\| where code >= 500`                       |
+| `{code=~"500\|502\|503"}`    | `\| where code == 500 or code == 502 or code == 503` |
+
+**Bool-typed tag:** `{flag="true"}` → `| where flag == true`.
+
+**Worked example:**
+
+```promql
+http_request_duration_seconds_count{
+  container=~"api|web",
+  path=~".*\/v1\/(traces|logs|metrics).*",
+  code!~"[1234].."
+}
+```
+
+Probe each tag's type before authoring (per the type-fetch rule above):
+
+```bash
+scripts/metrics/metrics-query test '`test`:`http_request_duration_seconds_count` | filter `code` is int | align to 5m using sum' now-1h now
+```
+
+Non-empty result confirms `code` is `int`-typed. Repeat for `container` and `path` with `is string`. If `code` came back empty for `is int` and non-empty for `is string`, the dataset stores `code` as a string and you'd translate the regex form instead (`| where code == #/[5-9]../`) — see the string-typed table above.
+
+In MPL, with `container` and `path` confirmed as strings and `code` confirmed as int:
+
+```mpl
+test:http_request_duration_seconds_count
+| where container == #/api|web/
+| where path == #/.*\/v1\/(traces|logs|metrics).*/
+| where code >= 500
+```
+
+The `code!~"[1234].."` regex (Prom's only way to express "5xx or higher") collapses to `where code >= 500` — a typed comparison the dataset can satisfy directly.
+
+**Backticking non-identifier names.** MPL identifiers that contain dots (or other non-alphanumeric characters) must be backtick-escaped: `` `service.name` ``, `` `kubernetes.pod.name` ``. The metric name itself is also backtick-escaped when it contains dots: `` `http.server.duration` ``.
+
+---
+
+## Aggregation translation: `rate(...)` and friends
+
+PromQL aggregation operators map onto MPL's `align`, `group`, and `bucket` operators. The translation preserves the semantic; idiomatic MPL is shorter than PromQL because MPL composes left-to-right instead of nesting.
+
+### Rate
+
+`rate(metric[5m])` becomes `align to 5m using prom::rate`. The Prom range vector duration becomes the `align` window.
+
+```promql
+rate(http_requests_total{path="/api"}[5m])
+```
+
+```mpl
+test:http_requests_total
+| where path == "/api"
+| align to 5m using prom::rate
+```
+
+> **Why `prom::rate` and not `rate`?** `prom::rate` preserves Prometheus semantics (handles counter resets, extrapolates over the window). Use it for any translation from PromQL `rate()`. Plain `rate` exists for native MPL use cases where you do not want Prom's extrapolation. When in doubt, match the source: PromQL `rate(...)` → `prom::rate`. Confirm operator availability with `scripts/metrics/metrics-spec` before authoring.
+
+### Other aggregations
+
+| PromQL                          | MPL                                                |
+|:--------------------------------|:---------------------------------------------------|
+| `sum(metric)`                   | `\| group using sum`                               |
+| `sum by (a, b) (metric)`        | `\| group by a, b using sum`                       |
+| `avg by (a) (rate(metric[5m]))` | `\| align to 5m using prom::rate \| group by a using avg` |
+| `max_over_time(metric[7d])`     | `\| group using max \| align to 7d using avg`      |
+| `min by (a) (metric)`           | `\| group by a using min`                          |
+| `count by (a) (metric)`         | `\| group by a using count`                        |
+
+### `by(...)` is mandatory to preserve
+
+The single most common F3 failure: dropping a dimension from `by(...)` because the metric name "feels" scoped to one of them. Never do this — the dimension was specified for a reason. Drop one and the resulting chart has the wrong shape.
+
+```promql
+sum by (instance, name) (workqueue_depth)   // two dimensions, both required
+```
+
+```mpl
+test:workqueue_depth
+| group by instance, name using sum         // both dimensions preserved
+```
+
+---
+
+## Histogram translation: `histogram_quantile(...)` → `bucket … using interpolate_*_histogram(...)`
+
+PromQL histograms are three derived series (`_bucket`, `_sum`, `_count`); a histogram_quantile pipeline reduces them via a sum-by-le, then computes a quantile. MPL collapses this into a single `bucket` operator that takes the quantile as a function argument.
+
+```promql
+histogram_quantile(0.90,
+  sum by (method, path, le) (
+    rate(http_request_duration_seconds_bucket{service="api"}[5m])
+  )
+)
+```
+
+```mpl
+test:http_request_duration_seconds_bucket
+| where service == "api"
+| bucket by method, path to 5m using interpolate_cumulative_histogram(rate, 0.90, 0.99)
+```
+
+**Two things drop out** of the literal translation, structurally:
+
+1. **The `le` dimension drops from the `by` list.** MPL handles bucket boundaries internally; surfacing `le` would be redundant. The `by(method, path, le)` becomes `bucket by method, path` — `le` is gone.
+2. **The outer `rate(...)` collapses into the bucket call** as the rate argument: `interpolate_cumulative_histogram(rate, 0.90, …)`. The `[5m]` Prom range becomes the `bucket … to 5m` window.
+
+**Pick the right histogram operator** for the metric's temporality. Cumulative histograms (the OTel default) use `interpolate_cumulative_histogram`. Delta histograms use `interpolate_delta_histogram`. Read the metric's `temporality` from `scripts/metrics/metrics-info <deploy> <dataset> metrics <metric> info` before choosing — this is part of the metric metadata, not a guess.
+
+---
+
+## Boolean step functions: `<bool` and friends
+
+PromQL's `<bool 0.4` expression returns 0 or 1 per timestamp depending on whether the value is below the threshold. MPL expresses this with `map is::lt(0.4)` (and analogous predicates).
+
+```promql
+(metric <bool 0.4)
+```
+
+```mpl
+| map is::lt(0.4)
+```
+
+Common predicates: `is::lt`, `is::le`, `is::gt`, `is::ge`, `is::eq`, `is::ne`. Confirm names against `metrics-spec` for the dataset — operator availability evolves.
+
+---
+
+## Ratios and division: `compute … using /`
+
+PromQL ratio expressions — `sum(rate(errors[5m])) / sum(rate(total[5m]))` — translate to MPL `compute` blocks that join two parenthesized branches.
+
+```promql
+sum(rate(http_requests_total{outcome="failure"}[5m]))
+/
+sum(rate(http_requests_total[5m]))
+```
+
+```mpl
+(
+  test:http_requests_total
+  | where outcome == "failure"
+  | align to 5m using prom::rate
+  | group using sum,
+  test:http_requests_total
+  | align to 5m using prom::rate
+  | group using sum
+)
+| compute error_rate using /
+```
+
+**Two notes for translators:**
+
+1. **Both branches must have the same shape** — same `align` window, same grouping. If one has `group by service` and the other doesn't, the join will not line up.
+2. **Ratios are 0–1 fractions, not percentages.** If the chart is a Statistic with `unit: "Percent100"`, multiply by 100 in MPL before deploying: `| map * 100`. See [chart-config.md § Unit Configuration](./chart-config.md#unit-configuration-cross-chart) and [metrics-mpl.md § Percentages and ratios](./metrics-mpl.md#percentages-and-ratios-otel-01-fractions).
+
+For naming a branch in `compute`, use the `as` keyword: `test:http_requests_total as failure`. Helpful when the same metric appears twice with different filters.
+
+---
+
+## Reverse-Tag Discovery for Missing Labels
+
+When a PromQL label name does not exist verbatim in the MPL dataset *after* applying OTel rename rules — e.g. PromQL has `{job="ingest-worker"}` but the dataset has no `job` tag — **do not drop the selector**. The selector was authored deliberately; the dataset just spells the dimension differently.
+
+### Workflow
+
+1. **List all tags in the dataset.**
+   ```bash
+   scripts/metrics/metrics-info <deploy> <dataset> tags
+   ```
+2. **Inspect candidate values.** Pick the most likely candidate (often `service.name` for `job`, `k8s.pod.name` for `instance`, etc.) and confirm:
+   ```bash
+   scripts/metrics/metrics-info <deploy> <dataset> tags <candidate> values
+   ```
+   Look for the value the PromQL selector matched on.
+3. **Map the selector** to the equivalent tag.
+   ```promql
+   {job="ingest-worker"}
+   ```
+   ```mpl
+   | where `service.name` == "ingest-worker"
+   ```
+4. **If no equivalent exists,** surface the mismatch to the user as a blocker. Document the panel as deferred. **Never silently drop the selector** — that ships a wrong-shape dashboard.
+
+### Discovery cap
+
+Cap reverse-search at **two candidates** before surfacing a question. If two reasonable candidate tags don't carry the expected value, the dataset probably doesn't model the dimension and the user has to decide. Burning ten discovery calls on a hunch is a smell, not diligence.
+
+### What discovery does NOT do
+
+Discovery validates that the spec'd subset exists in the dataset. It **does not** invent a subset. If you find yourself running `metrics-info` to *decide* what the panel should filter on, stop — the source dashboard already wrote that down. (See also [grafana-migration.md § Common Migration Pitfalls](./grafana-migration.md#common-migration-pitfalls).)
+
+---
+
+## Selector Values Not in the Dataset Are Aliases — Cite the Source
+
+When a PromQL selector value is **absent** from the dataset's tag values, the value is a recording-rule alias or other shorthand defined elsewhere — not a literal value to translate. Shape of the case: PromQL has `{<label>="<alias>"}`, but `metrics-info … tags <label> values` returns a set that does not include `"<alias>"`. The alias resolves to some subset `{A, B, …}` of the values that *are* in the dataset, but the subset is defined outside the dashboard JSON.
+
+Resolve the alias by citing a **written source**:
+
+- the panel's `description` field (often enumerates the subset in prose), **or**
+- the upstream rule library file and line (e.g. `<rule-library>.<ext>:L<n>`).
+
+**Memory is not a source.** Prior knowledge of an upstream rule library is unreliable — agents recall the *shape* of definitions more confidently than they recall the exact contents, and rule libraries get edited over time. The failure mode on file: an agent expanded an alias from memory instead of opening either the panel `description` or the upstream rule definition; both written sources agreed on the subset, the agent's recall matched neither, and the deployed panel filtered a different subset than the source dashboard. The fix is procedural: **no expansion of an alias may be attributed to general knowledge — produce a citation, or defer the panel with a Note.**
+
+Detection trigger: `metrics-info <deploy> <dataset> tags <label> values` does not contain the value the PromQL selector expects. That absence is the cue that an alias is in play; from that moment forward, prior-knowledge expansion is forbidden.
+
+---
+
+## Translation Checklist
+
+Per panel:
+
+- [ ] Applied OTel metric-name rename rules to every metric in `expr` (drop `_total`, decompose histogram derivatives, normalize unit suffixes).
+- [ ] Validated each renamed metric name with `metrics-info` (or marked the chart blocked).
+- [ ] Resolved label names via `metrics-info … tags` — not via assumed renaming. Reverse-search if absent (capped at 2 candidates).
+- [ ] **For every PromQL selector value not present in `metrics-info … tags <label> values`: cited a written source for the expansion** (panel `description`, or upstream rule library file + line). Memory-as-source is forbidden; no citation → defer the panel. See [§ Selector Values Not in the Dataset Are Aliases](#selector-values-not-in-the-dataset-are-aliases--cite-the-source).
+- [ ] For each PromQL `{…}` matcher: produced a corresponding MPL `where` clause (regex `=~` → `== #/…/`, etc.).
+- [ ] For each PromQL `by(…)` dimension: included it in the MPL `group by` (or `bucket by` for histograms).
+- [ ] For each `rate(metric[X])`: produced `align to X using prom::rate`.
+- [ ] For each `histogram_quantile(...)`: chose `interpolate_cumulative_histogram` or `interpolate_delta_histogram` based on the metric's `temporality` metadata.
+- [ ] For each ratio: built a `compute … using /` block, branches with matching shape; multiplied by 100 if the chart is `Percent100`.
+- [ ] For each missing label: ran reverse-tag discovery (capped at 2 candidates), surfaced a blocker rather than dropping the selector.
+- [ ] No inline time ranges on the MPL source.
+- [ ] Tested via `scripts/metrics/metrics-query`, preserving `$__interval` (with `param` declaration and `-p __interval=…`).
+- [ ] Spot-checked: does each translated panel filter the same subset and group by the same dimensions as the original?

--- a/skills/building-dashboards/reference/templates/org-usage-cost-control.json
+++ b/skills/building-dashboards/reference/templates/org-usage-cost-control.json
@@ -136,7 +136,6 @@
       "errorThresholdValue": "25",
       "id": "wow-change",
       "name": "Week-over-Week",
-      "overrideDashboardTimeRange": true,
       "query": {
         "apl": "declare query_parameters (org_filter:string = \"\", dataset_filter:string = \"\");\n['axiom-audit']\n| where _time between (ago(14d) .. now())\n| where action == 'usageCalculated'\n| where isempty(org_filter) or ['resource.id'] == org_filter\n| where isempty(dataset_filter) or tostring(['properties.dataset']) == dataset_filter\n| summarize this_week = sumif(['properties.hourly_ingest_bytes'], _time >= ago(7d)), last_week = sumif(['properties.hourly_ingest_bytes'], _time < ago(7d) and _time >= ago(14d))\n| extend ['WoW %'] = iff(last_week == 0, real(null), round(100.0 * (this_week - last_week) / last_week, 1))\n| project ['WoW %']"
       },
@@ -144,7 +143,6 @@
       "warningThreshold": "Above",
       "warningThresholdValue": "10"
     },
-
     {
       "colorScheme": "Green",
       "id": "active-datasets",
@@ -160,8 +158,6 @@
       "modified": 1769193868070,
       "name": "Daily Ingest by Dataset (GB)",
       "numSeries": 1,
-      "overrideDashboardCompareAgainst": false,
-      "overrideDashboardTimeRange": false,
       "query": {
         "apl": "declare query_parameters (org_filter:string = \"\", dataset_filter:string = \"\");\n[\"axiom-audit\"]\n| where action == \"usageCalculated\"\n| where isempty(org_filter) or [\"resource.id\"] == org_filter\n| where isempty(dataset_filter) or tostring([\"properties.dataset\"]) == dataset_filter\n| summarize [\"GB\"] = round(sum([\"properties.hourly_ingest_bytes\"]) / 1000000000, 1) by bin(_time, 1d), Dataset = tostring([\"properties.dataset\"])",
         "endTime": "",
@@ -190,9 +186,18 @@
       },
       "tableSettings": {
         "columns": [
-          {"name": "Dataset", "width": 200},
-          {"name": "Ingest GB", "width": 100},
-          {"name": "Query GB·ms", "width": 120}
+          {
+            "name": "Dataset",
+            "width": 200
+          },
+          {
+            "name": "Ingest GB",
+            "width": 100
+          },
+          {
+            "name": "Query GB·ms",
+            "width": 120
+          }
         ]
       },
       "type": "Table"
@@ -205,10 +210,22 @@
       },
       "tableSettings": {
         "columns": [
-          {"name": "Dataset", "width": 200},
-          {"name": "Ingest GB", "width": 100},
-          {"name": "Query GB·ms", "width": 120},
-          {"name": "Work/GB", "width": 90}
+          {
+            "name": "Dataset",
+            "width": 200
+          },
+          {
+            "name": "Ingest GB",
+            "width": 100
+          },
+          {
+            "name": "Query GB·ms",
+            "width": 120
+          },
+          {
+            "name": "Work/GB",
+            "width": 90
+          }
         ]
       },
       "type": "Table"
@@ -221,10 +238,22 @@
       },
       "tableSettings": {
         "columns": [
-          {"name": "Org", "width": 180},
-          {"name": "Ingest GB", "width": 100},
-          {"name": "Query GB·ms", "width": 120},
-          {"name": "Datasets", "width": 80}
+          {
+            "name": "Org",
+            "width": 180
+          },
+          {
+            "name": "Ingest GB",
+            "width": 100
+          },
+          {
+            "name": "Query GB·ms",
+            "width": 120
+          },
+          {
+            "name": "Datasets",
+            "width": 80
+          }
         ]
       },
       "type": "Table"
@@ -255,11 +284,26 @@
       },
       "tableSettings": {
         "columns": [
-          {"name": "Dataset", "width": 180},
-          {"name": "This Week GB", "width": 110},
-          {"name": "Last Week GB", "width": 110},
-          {"name": "Delta GB", "width": 90},
-          {"name": "Delta %", "width": 80}
+          {
+            "name": "Dataset",
+            "width": 180
+          },
+          {
+            "name": "This Week GB",
+            "width": 110
+          },
+          {
+            "name": "Last Week GB",
+            "width": 110
+          },
+          {
+            "name": "Delta GB",
+            "width": 90
+          },
+          {
+            "name": "Delta %",
+            "width": 80
+          }
         ]
       },
       "type": "Table"
@@ -272,9 +316,18 @@
       },
       "tableSettings": {
         "columns": [
-          {"name": "User", "width": 250},
-          {"name": "Cost GB·ms", "width": 120},
-          {"name": "Queries", "width": 80}
+          {
+            "name": "User",
+            "width": 250
+          },
+          {
+            "name": "Cost GB·ms",
+            "width": 120
+          },
+          {
+            "name": "Queries",
+            "width": 80
+          }
         ]
       },
       "type": "Table"
@@ -287,9 +340,18 @@
       },
       "tableSettings": {
         "columns": [
-          {"name": "User", "width": 180},
-          {"name": "Cost GB·ms", "width": 100},
-          {"name": "Query", "width": 300}
+          {
+            "name": "User",
+            "width": 180
+          },
+          {
+            "name": "Cost GB·ms",
+            "width": 100
+          },
+          {
+            "name": "Query",
+            "width": 300
+          }
         ]
       },
       "type": "Table"
@@ -338,11 +400,26 @@
       },
       "tableSettings": {
         "columns": [
-          {"name": "Dataset", "width": 140},
-          {"name": "Field", "width": 180},
-          {"name": "Op", "width": 70},
-          {"name": "Value", "width": 150},
-          {"name": "Queries", "width": 80}
+          {
+            "name": "Dataset",
+            "width": 140
+          },
+          {
+            "name": "Field",
+            "width": 180
+          },
+          {
+            "name": "Op",
+            "width": 70
+          },
+          {
+            "name": "Value",
+            "width": 150
+          },
+          {
+            "name": "Queries",
+            "width": 80
+          }
         ]
       }
     }
@@ -353,26 +430,146 @@
   ],
   "description": "Usage monitoring dashboard for tracking ingest volume, query costs, burn rate projections, and waste identification. Filter by org to scope analysis.",
   "layout": [
-    { "i": "filters", "x": 0, "y": 0, "w": 12, "h": 1 },
-    { "i": "total-ingest-gb", "x": 0, "y": 1, "w": 3, "h": 2 },
-    { "i": "daily-burn-rate", "x": 3, "y": 1, "w": 3, "h": 2 },
-    { "i": "monthly-projection", "x": 6, "y": 1, "w": 3, "h": 2 },
-    { "i": "over-contract-pct", "x": 9, "y": 1, "w": 3, "h": 2 },
-    { "i": "required-cut-pct", "x": 0, "y": 3, "w": 3, "h": 2 },
-    { "i": "wow-change", "x": 3, "y": 3, "w": 3, "h": 2 },
-    { "i": "total-query-cost", "x": 6, "y": 3, "w": 3, "h": 2 },
-    { "i": "active-datasets", "x": 9, "y": 3, "w": 3, "h": 2 },
-    { "i": "ingest-by-dataset-ts", "x": 0, "y": 5, "w": 6, "h": 4 },
-    { "i": "query-cost-by-dataset-ts", "x": 6, "y": 5, "w": 6, "h": 4 },
-    { "i": "wow-ingest-delta", "x": 0, "y": 9, "w": 6, "h": 4 },
-    { "i": "waste-candidates", "x": 6, "y": 9, "w": 6, "h": 4 },
-    { "i": "top-datasets-ingest", "x": 0, "y": 13, "w": 6, "h": 4 },
-    { "i": "top-orgs", "x": 6, "y": 13, "w": 6, "h": 4 },
-    { "i": "top-queried-fields", "x": 0, "y": 17, "w": 6, "h": 4 },
-    { "i": "note-actions", "x": 6, "y": 17, "w": 6, "h": 4 },
-    { "i": "top-users-query-cost", "x": 0, "y": 21, "w": 6, "h": 4 },
-    { "i": "top-expensive-queries", "x": 6, "y": 21, "w": 6, "h": 4 },
-    { "i": "queries-per-user-ts", "x": 0, "y": 25, "w": 12, "h": 4 }
+    {
+      "i": "filters",
+      "x": 0,
+      "y": 0,
+      "w": 12,
+      "h": 1
+    },
+    {
+      "i": "total-ingest-gb",
+      "x": 0,
+      "y": 1,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "daily-burn-rate",
+      "x": 3,
+      "y": 1,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "monthly-projection",
+      "x": 6,
+      "y": 1,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "over-contract-pct",
+      "x": 9,
+      "y": 1,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "required-cut-pct",
+      "x": 0,
+      "y": 3,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "wow-change",
+      "x": 3,
+      "y": 3,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "total-query-cost",
+      "x": 6,
+      "y": 3,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "active-datasets",
+      "x": 9,
+      "y": 3,
+      "w": 3,
+      "h": 2
+    },
+    {
+      "i": "ingest-by-dataset-ts",
+      "x": 0,
+      "y": 5,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "query-cost-by-dataset-ts",
+      "x": 6,
+      "y": 5,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "wow-ingest-delta",
+      "x": 0,
+      "y": 9,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "waste-candidates",
+      "x": 6,
+      "y": 9,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "top-datasets-ingest",
+      "x": 0,
+      "y": 13,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "top-orgs",
+      "x": 6,
+      "y": 13,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "top-queried-fields",
+      "x": 0,
+      "y": 17,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "note-actions",
+      "x": 6,
+      "y": 17,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "top-users-query-cost",
+      "x": 0,
+      "y": 21,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "top-expensive-queries",
+      "x": 6,
+      "y": 21,
+      "w": 6,
+      "h": 4
+    },
+    {
+      "i": "queries-per-user-ts",
+      "x": 0,
+      "y": 25,
+      "w": 12,
+      "h": 4
+    }
   ],
   "name": "Org Usage & Cost Control",
   "owner": "8bc79245-bc38-4a2b-a37e-2e5b2fd5ec70",

--- a/skills/building-dashboards/scripts/chart-add
+++ b/skills/building-dashboards/scripts/chart-add
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# chart-add: Emit a valid Axiom dashboard chart JSON object on stdout.
+#
+# The agent supplies *semantic* inputs (id, name, query, unit-as-string).
+# This script applies all the API-shape rules:
+#
+# - APL vs MPL are distinct languages with distinct validation, and the
+#   flags reflect that:
+#     --apl '<APL pipeline>'        → events/logs query (no dataset arg)
+#     --mpl '<MPL pipeline>' --dataset <name>  → metrics query
+#   Internally both land in `query.apl` (the API field is shared); MPL
+#   additionally gets `query.metricsDataset`, which is what tells the
+#   backend to interpret the string as MPL.
+#
+# - MPL-specific validation:
+#     • Inline time ranges (`[1h..]`, `[30d..]`, etc.) are rejected at
+#       chart construction. They deploy fine but render with
+#       `AST Error (Time is provided both in the query and as a parameter)`
+#       because the dashboard runtime always supplies start/end via the
+#       API. Use `align to $__interval using …` for bucketing.
+#
+# - Statistic gets BOTH `unit` (enum, e.g. Percent100) AND `customUnits`
+#   (suffix, e.g. "%"). The mapping is delegated to scripts/metrics/unit-for,
+#   which already handles UCUM → Axiom-enum lookup, the "%" double-emit,
+#   and the "1" / "By" / "m" ambiguities.
+# - TimeSeries / Table / Pie / LogStream / Heatmap accept ONLY `customUnits`
+#   (never the `unit` enum — the create API rejects it). They get the raw
+#   unit string passed verbatim as customUnits.
+# - Note has neither — only `text` (top-level, never inside an `options{}`
+#   wrapper).
+# - Always-rejected fields (`description`, `options`,
+#   `overrideDashboardTimeRange`, `overrideDashboardCompareAgainst`,
+#   `decimals`) are NEVER emitted, regardless of input.
+# - Thresholds: NOT exposed yet. The API accepts `errorThreshold` /
+#   `warningThreshold` as bare string enums (`Above`/`AboveOrEqual`/
+#   `Below`/`BelowOrEqual`/`AboveOrBelow`) but the companion *value*
+#   field is not reachable through the create API on the deployments
+#   probed so far — anything we tried (`thresholdValue`, `errorValue`,
+#   numeric `errorThreshold`, etc.) is rejected as `Unrecognized keys`.
+#   Once the value field is documented or returned by `dashboard-get`
+#   on a UI-authored chart, add `--warn-when` / `--error-when` flags
+#   here. Until then, set thresholds via the UI.
+#
+# Usage:
+#   chart-add --type <type> --id <id> --name <name> [type-specific opts]
+#
+# Types: Note, Statistic, TimeSeries, Table, Pie, LogStream, Heatmap
+#
+# Per-type required flags:
+#   Note:       --text <markdown>
+#   All others: exactly one of --apl <APL> or --mpl <MPL> --dataset <name>
+#
+# Common optional flags (data charts only):
+#   --unit <string>      Friendly unit string ("%", "s", "ms", "B",
+#                        "req/s", "bytes", etc.). For Statistic, mapped
+#                        via unit-for. For other charts, becomes
+#                        customUnits verbatim.
+#
+# Statistic-only flags:
+#   --show-chart         Render a sparkline behind the value
+#
+# Examples:
+#   chart-add --type Note --id intro --name Notice --text "**Scope:** ..."
+#
+#   # APL / events
+#   chart-add --type Table --id top-errs --name "Top Errors" \
+#       --apl "['logs'] | where status >= 500 | summarize count() by route | top 10 by count_"
+#
+#   # MPL / metrics
+#   chart-add --type Statistic --id avail --name "Availability (30d)" \
+#       --mpl '...MPL...' --dataset k8s-metrics-staging --unit "%"
+#
+#   chart-add --type TimeSeries --id rps --name "Read Requests (req/s)" \
+#       --mpl '...MPL...' --dataset k8s-metrics-staging --unit "req/s"
+#
+# Composing a dashboard:
+#   chart-add --type Note ... > /tmp/c1.json
+#   chart-add --type Statistic ... > /tmp/c2.json
+#   layout-pack c1:Note c2:Statistic > /tmp/layout.json
+#   dashboard-assemble --name "..." --datasets ds --layout /tmp/layout.json \
+#                      /tmp/c1.json /tmp/c2.json > /tmp/dashboard.json
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNIT_FOR="$SCRIPT_DIR/metrics/unit-for"
+
+TYPE=""
+ID=""
+NAME=""
+APL=""
+MPL=""
+TEXT=""
+DATASET=""
+UNIT=""
+SHOW_CHART=""
+
+usage() {
+    sed -n '2,/^set -euo pipefail/p' "$0" | sed 's/^# \?//' | sed '$d'
+    exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --type)        TYPE="$2"; shift 2 ;;
+        --id)          ID="$2"; shift 2 ;;
+        --name)        NAME="$2"; shift 2 ;;
+        --apl)         APL="$2"; shift 2 ;;
+        --mpl)         MPL="$2"; shift 2 ;;
+        --text)        TEXT="$2"; shift 2 ;;
+        --dataset)     DATASET="$2"; shift 2 ;;
+        --unit)        UNIT="$2"; shift 2 ;;
+        --show-chart)  SHOW_CHART=1; shift ;;
+        -h|--help)     usage 0 ;;
+        *) echo "Error: unknown option '$1'" >&2; usage ;;
+    esac
+done
+
+# --- Required-flag validation -----------------------------------------------
+
+[[ -z "$TYPE" ]] && { echo "Error: --type is required" >&2; usage; }
+[[ -z "$ID"   ]] && { echo "Error: --id is required" >&2; usage; }
+[[ -z "$NAME" ]] && { echo "Error: --name is required" >&2; usage; }
+
+case "$TYPE" in
+    Note|Statistic|TimeSeries|Table|Pie|LogStream|Heatmap) ;;
+    *) echo "Error: --type must be one of: Note, Statistic, TimeSeries, Table, Pie, LogStream, Heatmap (got '$TYPE')" >&2; exit 1 ;;
+esac
+
+# --apl and --mpl are mutually exclusive everywhere they're allowed at all.
+if [[ -n "$APL" && -n "$MPL" ]]; then
+    echo "Error: --apl and --mpl are mutually exclusive (a chart is either an events/logs query or a metrics query, not both)" >&2
+    exit 1
+fi
+
+case "$TYPE" in
+    Note)
+        [[ -z "$TEXT" ]] && { echo "Error: --text is required for Note" >&2; exit 1; }
+        if [[ -n "$APL" || -n "$MPL" || -n "$DATASET" || -n "$UNIT" || -n "$SHOW_CHART" ]]; then
+            echo "Error: --apl, --mpl, --dataset, --unit, --show-chart are not valid for Note" >&2
+            exit 1
+        fi
+        ;;
+    Statistic|TimeSeries|Table|Pie|LogStream|Heatmap)
+        [[ -n "$TEXT" ]] && { echo "Error: --text is only valid for Note" >&2; exit 1; }
+        if [[ -z "$APL" && -z "$MPL" ]]; then
+            echo "Error: $TYPE requires exactly one of --apl <APL pipeline> or --mpl <MPL pipeline>" >&2
+            exit 1
+        fi
+        # MPL requires --dataset (the metrics dataset name); APL forbids it.
+        if [[ -n "$MPL" && -z "$DATASET" ]]; then
+            echo "Error: --mpl requires --dataset <name> (the metrics dataset; sets query.metricsDataset, which is what flags the chart as MPL on the backend)" >&2
+            exit 1
+        fi
+        if [[ -n "$APL" && -n "$DATASET" ]]; then
+            echo "Error: --dataset is for metrics charts only — pair it with --mpl, not --apl. (APL charts read from the dataset(s) declared at dashboard level.)" >&2
+            exit 1
+        fi
+        # Inline-range check is MPL-only. APL doesn't use [N..] time-range
+        # syntax (its time semantics live in `where _time between (...)`,
+        # which dashboards don't need anyway).
+        if [[ -n "$MPL" ]] && printf '%s' "$MPL" | grep -qE '\[[^]]*\.\.[^]]*\]'; then
+            echo "Error: --mpl contains an inline time range (e.g. [1h..]). Dashboard chart queries cannot use inline ranges — the dashboard time picker supplies start/end. Use 'align to \$__interval using …' for bucketing instead." >&2
+            exit 1
+        fi
+        ;;
+esac
+
+if [[ "$TYPE" != "Statistic" && -n "$SHOW_CHART" ]]; then
+    echo "Error: --show-chart is only valid for Statistic" >&2
+    exit 1
+fi
+
+# --- Helpers ---------------------------------------------------------------
+
+# Echo the unit-fields JSON object for a Statistic chart.
+# Empty input → {} (chart will render bare numbers; caller's choice).
+unit_fields_statistic() {
+    local u="$1"
+    if [[ -z "$u" ]]; then
+        echo '{}'
+        return
+    fi
+    "$UNIT_FOR" "$u"
+}
+
+# Echo the unit-fields JSON object for any non-Statistic data chart.
+# Always {customUnits: ...} or {} — never the `unit` enum (API rejects it).
+unit_fields_other() {
+    local u="$1"
+    if [[ -z "$u" ]]; then
+        echo '{}'
+    else
+        jq -n --arg u "$u" '{customUnits: $u}'
+    fi
+}
+
+# Build the query object. Both APL and MPL land in `query.apl` (shared API
+# field); MPL also gets `query.metricsDataset`.
+build_query() {
+    if [[ -n "$MPL" ]]; then
+        jq -n --arg apl "$MPL" --arg ds "$DATASET" '{apl: $apl, metricsDataset: $ds}'
+    else
+        jq -n --arg apl "$APL" '{apl: $apl}'
+    fi
+}
+
+# --- Emit chart JSON -------------------------------------------------------
+
+case "$TYPE" in
+    Note)
+        jq -n --arg id "$ID" --arg name "$NAME" --arg text "$TEXT" \
+            '{id: $id, name: $name, type: "Note", text: $text}'
+        ;;
+    Statistic)
+        UNIT_JSON=$(unit_fields_statistic "$UNIT")
+        QUERY_JSON=$(build_query)
+        RESULT=$(jq -n \
+            --arg id "$ID" \
+            --arg name "$NAME" \
+            --argjson query "$QUERY_JSON" \
+            --argjson unit "$UNIT_JSON" \
+            '{id: $id, name: $name, type: "Statistic", query: $query} + $unit')
+        if [[ -n "$SHOW_CHART" ]]; then
+            RESULT=$(jq '. + {showChart: true}' <<<"$RESULT")
+        fi
+        echo "$RESULT"
+        ;;
+    TimeSeries|Table|Pie|LogStream|Heatmap)
+        UNIT_JSON=$(unit_fields_other "$UNIT")
+        QUERY_JSON=$(build_query)
+        jq -n \
+            --arg id "$ID" \
+            --arg name "$NAME" \
+            --arg type "$TYPE" \
+            --argjson query "$QUERY_JSON" \
+            --argjson unit "$UNIT_JSON" \
+            '{id: $id, name: $name, type: $type, query: $query} + $unit'
+        ;;
+esac

--- a/skills/building-dashboards/scripts/dashboard-assemble
+++ b/skills/building-dashboards/scripts/dashboard-assemble
@@ -66,7 +66,7 @@
 #   chart-add --type Note --id intro --name Notice --text "..." \
 #     > /tmp/d/c-intro.json
 #   chart-add --type Statistic --id avail --name "Availability" \
-#       --apl '...' --dataset k8s-metrics-staging --unit "%" \
+#       --mpl '...' --dataset k8s-metrics-staging --unit "%" \
 #     > /tmp/d/c-avail.json
 #   layout-pack intro:Note avail:Statistic > /tmp/d/layout.json
 #

--- a/skills/building-dashboards/scripts/dashboard-assemble
+++ b/skills/building-dashboards/scripts/dashboard-assemble
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# dashboard-assemble: Compose a complete Axiom dashboard JSON from chart
+# files and a layout file, plus a small set of dashboard-level flags.
+#
+# The agent never has to load chart JSON into its context — it writes each
+# chart to a temp file via `chart-add`, the layout array via `layout-pack`,
+# and passes file paths here. The whole envelope (`owner`, `schemaVersion`,
+# `qr-` time-window prefixes, `refreshTime` validation, id cross-checks)
+# is owned by this script.
+#
+# Usage:
+#   dashboard-assemble \
+#     --name <NAME> \
+#     --datasets <NAME>[,<NAME>...] \
+#     --layout <FILE> \
+#     [--description <STR>] \
+#     [--time-window <SPEC>] \
+#     [--refresh <KEY|SECONDS>] \
+#     [--owner <STR>] \
+#     <CHART_FILE> [<CHART_FILE> ...] \
+#     > dashboard.json
+#
+# Required flags:
+#   --name      Dashboard name.
+#   --datasets  Comma-separated list of dataset names this dashboard reads.
+#               (Charts that use MPL also carry their own metricsDataset
+#               on `query.metricsDataset`; this top-level field is for
+#               permissions and dataset attachment.)
+#   --layout    Path to a JSON file containing the layout array (typically
+#               the output of `layout-pack`).
+#
+# Optional flags:
+#   --description  Dashboard-level description (Markdown).
+#   --time-window  Relative window for the start of the time picker.
+#                  Examples: "1h", "30d", "7d", "24h", "now-2h", or an
+#                  already-prefixed "qr-now-1h". The script normalises:
+#                    qr-*   → used verbatim
+#                    now-*  → prefixed with "qr-"
+#                    other  → prefixed with "qr-now-"
+#                  Defaults to "1h". The end is always `qr-now`.
+#   --refresh      One of:
+#                    oncall  → 60   (1 minute)
+#                    team    → 300  (5 minutes)
+#                    exec    → 900  (15 minutes)
+#                    <int>   → use directly. Must be ≥ 60 — the API
+#                             rejects shorter values on probed deployments.
+#                  Defaults to 60.
+#   --owner        Defaults to "X-AXIOM-EVERYONE" (the only value an API
+#                  token can use; private dashboards aren't supported via
+#                  token auth).
+#
+# Positional args: one or more chart JSON files. Each file may contain
+# either a single chart object {} or an array of charts [{},{}]. They are
+# concatenated in the order given (which becomes the order of `charts[]`
+# in the dashboard).
+#
+# Validation:
+#   - Every layout entry's `i` must match a chart `id`.
+#   - Every chart `id` must appear in the layout.
+#   - No duplicate chart ids.
+#
+# Output: a single dashboard JSON object on stdout, ready for
+# `dashboard-validate` and `dashboard-create`.
+#
+# Examples:
+#   chart-add --type Note --id intro --name Notice --text "..." \
+#     > /tmp/d/c-intro.json
+#   chart-add --type Statistic --id avail --name "Availability" \
+#       --apl '...' --dataset k8s-metrics-staging --unit "%" \
+#     > /tmp/d/c-avail.json
+#   layout-pack intro:Note avail:Statistic > /tmp/d/layout.json
+#
+#   dashboard-assemble \
+#       --name "API server v22" \
+#       --datasets k8s-metrics-staging \
+#       --time-window 30d \
+#       --refresh oncall \
+#       --layout /tmp/d/layout.json \
+#       /tmp/d/c-intro.json /tmp/d/c-avail.json \
+#     > /tmp/d/dashboard.json
+
+set -euo pipefail
+
+NAME=""
+DATASETS=""
+LAYOUT_FILE=""
+DESCRIPTION=""
+TIME_WINDOW="1h"
+REFRESH="60"
+OWNER="X-AXIOM-EVERYONE"
+CHART_FILES=()
+
+usage() {
+    sed -n '2,/^set -euo pipefail/p' "$0" | sed 's/^# \?//' | sed '$d'
+    exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --name)         NAME="$2"; shift 2 ;;
+        --datasets)     DATASETS="$2"; shift 2 ;;
+        --layout)       LAYOUT_FILE="$2"; shift 2 ;;
+        --description)  DESCRIPTION="$2"; shift 2 ;;
+        --time-window)  TIME_WINDOW="$2"; shift 2 ;;
+        --refresh)      REFRESH="$2"; shift 2 ;;
+        --owner)        OWNER="$2"; shift 2 ;;
+        -h|--help)      usage 0 ;;
+        --*)            echo "Error: unknown flag '$1'" >&2; exit 1 ;;
+        *)              CHART_FILES+=("$1"); shift ;;
+    esac
+done
+
+# --- Required-flag / argument validation ----------------------------------
+
+[[ -z "$NAME"        ]] && { echo "Error: --name is required" >&2; usage; }
+[[ -z "$DATASETS"    ]] && { echo "Error: --datasets is required" >&2; usage; }
+[[ -z "$LAYOUT_FILE" ]] && { echo "Error: --layout is required" >&2; usage; }
+
+if [[ ${#CHART_FILES[@]} -eq 0 ]]; then
+    echo "Error: at least one chart file argument is required" >&2
+    usage
+fi
+
+[[ -f "$LAYOUT_FILE" ]] || { echo "Error: layout file not found: $LAYOUT_FILE" >&2; exit 1; }
+for f in "${CHART_FILES[@]}"; do
+    [[ -f "$f" ]] || { echo "Error: chart file not found: $f" >&2; exit 1; }
+done
+
+# --- Time-window normalisation --------------------------------------------
+
+normalise_time_window() {
+    local w="$1"
+    case "$w" in
+        qr-*)   echo "$w" ;;
+        now-*)  echo "qr-$w" ;;
+        now)    echo "Error: --time-window cannot be 'now' (zero-length window)" >&2; return 1 ;;
+        "")     echo "Error: --time-window cannot be empty" >&2; return 1 ;;
+        *)      echo "qr-now-$w" ;;
+    esac
+}
+TIME_WINDOW_START=$(normalise_time_window "$TIME_WINDOW") || exit 1
+TIME_WINDOW_END="qr-now"
+
+# --- Refresh-rate normalisation -------------------------------------------
+
+normalise_refresh() {
+    local r="$1"
+    case "$r" in
+        oncall) echo 60 ;;
+        team)   echo 300 ;;
+        exec)   echo 900 ;;
+        ''|*[!0-9]*)
+            echo "Error: --refresh must be one of oncall|team|exec or a positive integer (got '$r')" >&2
+            return 1
+            ;;
+        *)
+            if (( r < 60 )); then
+                echo "Error: --refresh must be ≥ 60 (the create API rejects shorter values; got $r)" >&2
+                return 1
+            fi
+            echo "$r"
+            ;;
+    esac
+}
+REFRESH_TIME=$(normalise_refresh "$REFRESH") || exit 1
+
+# --- Datasets list parsing ------------------------------------------------
+
+DATASETS_JSON=$(jq -nc --arg s "$DATASETS" '$s | split(",") | map(select(length > 0))')
+
+# --- Charts array assembly ------------------------------------------------
+
+# For each chart file, treat its contents as either a single object {} or
+# an array of objects [{}], and concatenate.
+CHARTS_JSON=$(jq -s '
+    map(if type == "array" then .[] else . end)
+    | map(select(. != null))
+' "${CHART_FILES[@]}")
+
+# --- Layout array load ----------------------------------------------------
+
+LAYOUT_JSON=$(jq '.' "$LAYOUT_FILE")
+
+if ! echo "$LAYOUT_JSON" | jq -e 'type == "array"' >/dev/null; then
+    echo "Error: layout file must contain a JSON array, got $(echo "$LAYOUT_JSON" | jq -r 'type')" >&2
+    exit 1
+fi
+
+# --- Cross-validation: chart ids ↔ layout i ------------------------------
+#
+# Done in pure jq for portability (avoids bash 4 mapfile / declare -A; the
+# default macOS /bin/bash is 3.2). Computes three sets in one pass:
+#   dups                  — chart ids that appear more than once
+#   layout_missing_chart  — layout `i`s with no matching chart `id`
+#   chart_missing_layout  — chart `id`s with no matching layout `i`
+
+VALIDATION=$(jq -nc \
+    --argjson charts "$CHARTS_JSON" \
+    --argjson layout "$LAYOUT_JSON" \
+    '{
+        dups: ([$charts[].id] | group_by(.) | map(select(length > 1) | .[0])),
+        layout_missing_chart: ([$layout[].i] - [$charts[].id] | unique),
+        chart_missing_layout: ([$charts[].id] - [$layout[].i] | unique)
+    }')
+
+DUPS=$(echo "$VALIDATION" | jq -r '.dups | join(", ")')
+LAYOUT_ONLY=$(echo "$VALIDATION" | jq -r '.layout_missing_chart | join(", ")')
+CHART_ONLY=$(echo "$VALIDATION" | jq -r '.chart_missing_layout | join(", ")')
+
+if [[ -n "$DUPS" ]]; then
+    echo "Error: duplicate chart id(s) across chart files: $DUPS" >&2
+    exit 1
+fi
+if [[ -n "$LAYOUT_ONLY" ]]; then
+    echo "Error: layout entry references id(s) with no matching chart: $LAYOUT_ONLY" >&2
+    exit 1
+fi
+if [[ -n "$CHART_ONLY" ]]; then
+    echo "Error: chart id(s) with no matching layout entry: $CHART_ONLY" >&2
+    exit 1
+fi
+
+# --- Emit dashboard JSON --------------------------------------------------
+
+jq -n \
+    --arg name "$NAME" \
+    --arg description "$DESCRIPTION" \
+    --arg owner "$OWNER" \
+    --argjson datasets "$DATASETS_JSON" \
+    --argjson refreshTime "$REFRESH_TIME" \
+    --arg timeWindowStart "$TIME_WINDOW_START" \
+    --arg timeWindowEnd "$TIME_WINDOW_END" \
+    --argjson charts "$CHARTS_JSON" \
+    --argjson layout "$LAYOUT_JSON" \
+    '
+    {
+      name: $name,
+      owner: $owner,
+      datasets: $datasets,
+      refreshTime: $refreshTime,
+      schemaVersion: 2,
+      timeWindowStart: $timeWindowStart,
+      timeWindowEnd: $timeWindowEnd,
+      charts: $charts,
+      layout: $layout
+    }
+    | if ($description | length) > 0 then .description = $description else . end
+    '

--- a/skills/building-dashboards/scripts/dashboard-validate
+++ b/skills/building-dashboards/scripts/dashboard-validate
@@ -11,6 +11,11 @@
 #   5. Chart IDs match layout IDs
 #   6. LogStream queries have take limits
 #   7. Grid layout doesn't exceed 12 columns
+#   8. Per-chart-kind closed-field schema (mirrors the create API)
+#      - Source of truth: reference/chart-config.md
+#        § Fields Rejected on Create (Cross-Chart)
+#      - Verified empirically against staging create endpoint
+#        (28-cell + 3 null-value probes, 2026-05-08)
 #
 # Options:
 #   --strict  Treat warnings as errors
@@ -137,6 +142,59 @@ fi
 missing_min=$(jq -r '.layout[] | select(.minH == null or .minW == null) | .i' "$FILE" 2>/dev/null || true)
 if [[ -n "$missing_min" ]]; then
     info "$(echo "$missing_min" | wc -l | tr -d ' ') layout entries missing minH/minW (will be auto-fixed on deploy)"
+fi
+
+# 12. Per-chart-kind closed-field schema check.
+#
+# The create API rejects certain fields per chart kind with HTTP 400 and a
+# uniform error string:
+#   dashboard validation failed at [charts <i>]: Unrecognized key: "<field>"
+#
+# Rules (verified empirically; see reference/chart-config.md
+# § Fields Rejected on Create):
+#   - decimals    : rejected on every chart kind (universal)
+#   - description : rejected on every chart kind (universal; chart-level only,
+#                   the dashboard-level top-level description is fine)
+#   - options     : rejected on every chart kind (universal). Common
+#                   carry-over from Grafana text panels (options.content)
+#                   or over-generalization from Axiom's nested chart options
+#                   like tableSettings / aggChartOpts. Note `text` is a
+#                   top-level chart field, not nested under options.
+#   - unit        : rejected on TimeSeries, Heatmap, Pie, Table, LogStream, Note
+#                   (i.e. every kind except Statistic)
+#   - customUnits : rejected on Note only
+#
+# Only flag when the field is present AND non-null — the API treats null as
+# field-absent and strips the key on ingest, so null-valued rejected keys
+# create successfully. Flagging null would over-flag and block deploys for
+# payloads the API would actually accept.
+#
+# Unknown chart .type values are skipped silently — we don't have empirical
+# evidence for chart kinds the probe didn't cover, and false-flagging a valid
+# future kind is worse than missing one rejection.
+schema_violations=$(jq -r '
+  .charts | to_entries[] |
+    .key as $idx |
+    .value.type as $t |
+    .value as $c |
+    # Universal rejections
+    (if $c.decimals != null    then "\($idx)\tdecimals"    else empty end),
+    (if $c.description != null then "\($idx)\tdescription" else empty end),
+    (if $c.options != null     then "\($idx)\toptions"     else empty end),
+    # unit rejected on every kind except Statistic (only for kinds we have
+    # empirical evidence for)
+    (if (["TimeSeries","Heatmap","Pie","Table","LogStream","Note"] | index($t)) and $c.unit != null
+     then "\($idx)\tunit" else empty end),
+    # customUnits rejected on Note
+    (if $t == "Note" and $c.customUnits != null
+     then "\($idx)\tcustomUnits" else empty end)
+' "$FILE" 2>/dev/null || true)
+
+if [[ -n "$schema_violations" ]]; then
+    while IFS=$'\t' read -r idx field; do
+        [[ -z "$idx" ]] && continue
+        error "API will reject — dashboard validation failed at [charts $idx]: Unrecognized key: \"$field\""
+    done <<< "$schema_violations"
 fi
 
 # Summary

--- a/skills/building-dashboards/scripts/layout-pack
+++ b/skills/building-dashboards/scripts/layout-pack
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# layout-pack: Compute non-overlapping {i,x,y,w,h} layout entries for an
+# ordered list of chart IDs, packed row-major into the 12-column dashboard
+# grid.
+#
+# The agent supplies the *order* (which it cares about) and either an
+# explicit size or just a chart type (which carries a sensible default).
+# Layout coordinates — the part that's mechanical, error-prone, and easy
+# to get wrong by hand — fall out of the row-major pack.
+#
+# Usage:
+#   layout-pack <id-spec> [<id-spec> ...]
+#
+# Each <id-spec> is "id:Type" or "id:WxH":
+#   id:Type   — use the type's default size from the table below
+#   id:WxH    — explicit width × height, both positive integers, w in 1..12
+#
+# Default sizes by type:
+#   Note         12 x 2   (full-width header)
+#   Statistic     3 x 3   (KPI tile, 4 fit per row)
+#   TimeSeries    6 x 4   (half-width chart, 2 per row)
+#   Heatmap       6 x 4
+#   Table         6 x 5
+#   Pie           4 x 4   (3 per row)
+#   LogStream    12 x 6   (full-width evidence pane)
+#   MonitorList   6 x 4
+#   SmartFilter  12 x 1   (filter bar)
+#
+# Packing rule: row-major, left-to-right. When the next chart would push
+# past column 12, start a new row whose y-offset equals the tallest chart
+# in the previous row. This preserves the agent's intended order and keeps
+# rows aligned without overlap.
+#
+# Output: a JSON array of {i,x,y,w,h} entries on stdout. `minH`/`minW` are
+# omitted — `dashboard-validate` auto-fills them on deploy.
+#
+# Examples:
+#   # Type-only — agent doesn't think about sizes at all
+#   layout-pack header:Note a:Statistic b:Statistic c:Statistic d:Statistic
+#
+#   # Mixed — explicit override for one chart
+#   layout-pack header:Note rps:TimeSeries errors:6x3 latency:TimeSeries
+#
+#   # Full dashboard skeleton
+#   layout-pack notice:Note \
+#               avail:Statistic budget:8x3 \
+#               read-avail:Statistic read-rps:TimeSeries read-err:TimeSeries read-lat:TimeSeries \
+#               cpu:TimeSeries mem:TimeSeries goroutines:TimeSeries
+#
+# Composing with chart-add:
+#   chart-add --type Note --id intro --name "..." --text "..."  > /tmp/c-intro.json
+#   chart-add --type Statistic --id avail --name "..." --apl '...' --dataset ds --unit "%" > /tmp/c-avail.json
+#   CHARTS=$(jq -s '.' /tmp/c-intro.json /tmp/c-avail.json)
+#   LAYOUT=$(layout-pack intro:Note avail:Statistic)
+#   jq -n --argjson c "$CHARTS" --argjson l "$LAYOUT" \
+#       '{name:"...",owner:"X-AXIOM-EVERYONE",datasets:["ds"],refreshTime:60,
+#         schemaVersion:2,timeWindowStart:"qr-now-1h",timeWindowEnd:"qr-now",
+#         charts:$c, layout:$l}' \
+#     > dashboard.json
+
+set -euo pipefail
+
+GRID_WIDTH=12
+
+usage() {
+    sed -n '2,/^set -euo pipefail/p' "$0" | sed 's/^# \?//' | sed '$d'
+    exit "${1:-1}"
+}
+
+if [[ $# -eq 0 ]]; then
+    echo "Error: at least one <id-spec> is required" >&2
+    usage
+fi
+
+for a in "$@"; do
+    [[ "$a" == "-h" || "$a" == "--help" ]] && usage 0
+done
+
+# Default size table — keep in sync with the docstring above.
+default_size() {
+    case "$1" in
+        Note)         echo "12 2" ;;
+        Statistic)    echo "3 3" ;;
+        TimeSeries)   echo "6 4" ;;
+        Heatmap)      echo "6 4" ;;
+        Table)        echo "6 5" ;;
+        Pie)          echo "4 4" ;;
+        LogStream)    echo "12 6" ;;
+        MonitorList)  echo "6 4" ;;
+        SmartFilter)  echo "12 1" ;;
+        *) return 1 ;;
+    esac
+}
+
+# Parse "id:spec" → echoes "id<TAB>w<TAB>h"; non-zero on bad input.
+parse_spec() {
+    local arg="$1"
+    if [[ "$arg" != *:* ]]; then
+        echo "Error: '$arg' must be of the form 'id:Type' or 'id:WxH'" >&2
+        return 1
+    fi
+    local id="${arg%%:*}"
+    local spec="${arg#*:}"
+    if [[ -z "$id" ]]; then
+        echo "Error: empty id in '$arg'" >&2
+        return 1
+    fi
+    local w h
+    if [[ "$spec" =~ ^([0-9]+)x([0-9]+)$ ]]; then
+        w="${BASH_REMATCH[1]}"
+        h="${BASH_REMATCH[2]}"
+    else
+        local pair
+        if ! pair=$(default_size "$spec"); then
+            echo "Error: '$spec' (in '$arg') is neither WxH nor a known chart type" >&2
+            return 1
+        fi
+        w="${pair% *}"
+        h="${pair#* }"
+    fi
+    if (( w < 1 )) || (( w > GRID_WIDTH )); then
+        echo "Error: width $w (in '$arg') out of range 1..$GRID_WIDTH" >&2
+        return 1
+    fi
+    if (( h < 1 )); then
+        echo "Error: height $h (in '$arg') must be ≥ 1" >&2
+        return 1
+    fi
+    printf '%s\t%s\t%s\n' "$id" "$w" "$h"
+}
+
+# Pack row-major.
+cursor_x=0
+cursor_y=0
+row_max_h=0
+seen_ids=()
+entries=()
+
+for arg in "$@"; do
+    parsed=$(parse_spec "$arg") || exit 1
+    id=$(printf '%s' "$parsed" | cut -f1)
+    w=$(printf '%s' "$parsed" | cut -f2)
+    h=$(printf '%s' "$parsed" | cut -f3)
+
+    # Reject duplicate ids — they corrupt the dashboard layout silently.
+    for prev in "${seen_ids[@]:-}"; do
+        if [[ -n "$prev" && "$prev" == "$id" ]]; then
+            echo "Error: duplicate id '$id'" >&2
+            exit 1
+        fi
+    done
+    seen_ids+=("$id")
+
+    # Wrap to next row if this chart would overflow the grid.
+    if (( cursor_x + w > GRID_WIDTH )); then
+        cursor_x=0
+        cursor_y=$((cursor_y + row_max_h))
+        row_max_h=0
+    fi
+
+    entries+=("$(jq -nc \
+        --arg i "$id" \
+        --argjson x "$cursor_x" \
+        --argjson y "$cursor_y" \
+        --argjson w "$w" \
+        --argjson h "$h" \
+        '{i: $i, x: $x, y: $y, w: $w, h: $h}')")
+
+    cursor_x=$((cursor_x + w))
+    if (( h > row_max_h )); then
+        row_max_h=$h
+    fi
+done
+
+printf '%s\n' "${entries[@]}" | jq -s '.'

--- a/skills/building-dashboards/scripts/layout-pack
+++ b/skills/building-dashboards/scripts/layout-pack
@@ -49,7 +49,7 @@
 #
 # Composing with chart-add:
 #   chart-add --type Note --id intro --name "..." --text "..."  > /tmp/c-intro.json
-#   chart-add --type Statistic --id avail --name "..." --apl '...' --dataset ds --unit "%" > /tmp/c-avail.json
+#   chart-add --type Statistic --id avail --name "..." --mpl '...' --dataset ds --unit "%" > /tmp/c-avail.json
 #   CHARTS=$(jq -s '.' /tmp/c-intro.json /tmp/c-avail.json)
 #   LAYOUT=$(layout-pack intro:Note avail:Statistic)
 #   jq -n --argjson c "$CHARTS" --argjson l "$LAYOUT" \

--- a/skills/building-dashboards/scripts/metrics/metrics-info
+++ b/skills/building-dashboards/scripts/metrics/metrics-info
@@ -4,10 +4,12 @@
 # Usage:
 #   metrics-info <deployment> <dataset> metrics [--by-type] [--type T]... [--start T --end T]
 #   metrics-info <deployment> <dataset> metrics <metric> info [--start T --end T]
-#   metrics-info <deployment> <dataset> tags    [--start T --end T]
-#   metrics-info <deployment> <dataset> tags <tag> values [--start T --end T]
+#   metrics-info <deployment> <dataset> metrics <metric> describe [--no-values] [--values-limit N] [--start T --end T]
 #   metrics-info <deployment> <dataset> metrics <metric> tags [--start T --end T]
 #   metrics-info <deployment> <dataset> metrics <metric> tags <tag> values [--start T --end T]
+#   metrics-info <deployment> <dataset> metrics <metric> tags <tag> type [--start T --end T]
+#   metrics-info <deployment> <dataset> tags    [--start T --end T]
+#   metrics-info <deployment> <dataset> tags <tag> values [--start T --end T]
 #   metrics-info <deployment> <dataset> find-metrics <search-value> [--start T --end T]
 #
 # Metric metadata. The `metrics` listing returns a v2 payload where each entry
@@ -23,14 +25,27 @@
 #                       Repeatable; multiple --type flags act as OR.
 #                       Composes with --by-type.
 #
-# The `metrics <metric> info` subcommand extracts a single metric's metadata
-# block ({type, temporality, unit}) from the bulk listing. Exits non-zero if
-# the metric is not present in the listing for the given time range.
+# `metrics <metric> info` extracts a single metric's metadata block
+# ({type, temporality, unit}). Non-zero exit if the metric is absent.
 #
-# find-metrics searches TAG VALUES, not metric names. It returns metrics that have
-# a tag containing the given value. Use it when you know a specific entity name
-# (service, host, device) to find which metrics are associated with it.
-# To list metric names, use the "metrics" subcommand instead.
+# `metrics <metric> describe` bundles metadata + tags + tag values for one
+# metric in a single call (replaces the typical 1+1+N round trips).
+#   --no-values         Return tag names only, not values (1+1 calls).
+#   --values-limit N    Cap each tag's value list at N entries (default 50;
+#                       0 = no limit). Applied client-side after fetch.
+#
+# `metrics <metric> tags <tag> type` probes whether a tag is int/float/string/
+# bool-typed by running `metrics-query` with `filter <tag> is <T>` for each.
+# Returns:
+#   {"type": "int", "present_types": ["int"]}
+#   {"type": "mixed", "present_types": ["int","string"]}
+#   {"type": "absent", "present_types": []}
+# (mixed = the tag carries different types across rows; use the defensive
+# `(tag is int and tag == 200) or (tag is string and tag == "200")` form.)
+#
+# find-metrics searches TAG VALUES, not metric names. Use it when you know a
+# specific entity name (service, host, device) to find which metrics carry it.
+# To list metric names, use the `metrics` subcommand instead.
 #
 # --start and --end default to the last 24 hours if omitted.
 # For sparse metrics (sensors, batch jobs), try --start with a wider range (e.g. 7 days).
@@ -41,6 +56,9 @@
 #   metrics-info prod my-dataset metrics --type Histogram               # Only histograms
 #   metrics-info prod my-dataset metrics --type Gauge --type Histogram --by-type
 #   metrics-info prod my-dataset metrics http.server.duration info      # Single metric meta
+#   metrics-info prod my-dataset metrics http.server.duration describe  # Bundle: meta + tags + values
+#   metrics-info prod my-dataset metrics http.server.duration describe --no-values
+#   metrics-info prod my-dataset metrics http.server.duration tags code type
 #   metrics-info prod my-dataset tags service.name values               # List values for a tag
 #   metrics-info prod my-dataset find-metrics "frontend"                # Find metrics with tag value "frontend"
 #   metrics-info prod my-dataset metrics http.server.duration tags --start 2025-06-01T00:00:00Z --end 2025-06-02T00:00:00Z
@@ -53,17 +71,21 @@ show_usage() {
     echo "Usage:" >&2
     echo "  metrics-info <deploy> <dataset> metrics [--by-type] [--type T]..." >&2
     echo "  metrics-info <deploy> <dataset> metrics <metric> info" >&2
+    echo "  metrics-info <deploy> <dataset> metrics <metric> describe [--no-values] [--values-limit N]" >&2
     echo "  metrics-info <deploy> <dataset> metrics <metric> tags" >&2
     echo "  metrics-info <deploy> <dataset> metrics <metric> tags <tag> values" >&2
+    echo "  metrics-info <deploy> <dataset> metrics <metric> tags <tag> type" >&2
     echo "  metrics-info <deploy> <dataset> tags" >&2
     echo "  metrics-info <deploy> <dataset> tags <tag> values" >&2
     echo "  metrics-info <deploy> <dataset> find-metrics <search-value>  (searches tag values, not metric names)" >&2
     echo "" >&2
     echo "Options:" >&2
-    echo "  --start T    Start time (RFC3339). Default: 24h ago" >&2
-    echo "  --end T      End time (RFC3339). Default: now" >&2
-    echo "  --by-type    (metrics listing) Group entries by metric type" >&2
-    echo "  --type T     (metrics listing) Filter to type T (Gauge|CounterMonotonic|CounterNonMonotonic|Histogram). Repeatable." >&2
+    echo "  --start T          Start time (RFC3339). Default: 24h ago" >&2
+    echo "  --end T            End time (RFC3339). Default: now" >&2
+    echo "  --by-type          (metrics listing) Group entries by metric type" >&2
+    echo "  --type T           (metrics listing) Filter to type T. Repeatable." >&2
+    echo "  --no-values        (describe) Return tag names only" >&2
+    echo "  --values-limit N   (describe) Cap each tag's value list at N (default 50; 0 = unlimited)" >&2
     exit 1
 }
 
@@ -76,19 +98,23 @@ fi
 
 shift 2
 
-# Collect positional args and parse --start/--end and listing-view flags
+# Collect positional args and parse --start/--end, listing-view, describe flags.
 POSITIONAL=()
 START=""
 END=""
 BY_TYPE=0
 TYPE_FILTERS=()
+NO_VALUES=0
+VALUES_LIMIT=50
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --start)    START="$2"; shift 2 ;;
-        --end)      END="$2"; shift 2 ;;
-        --by-type)  BY_TYPE=1; shift ;;
-        --type)     TYPE_FILTERS+=("$2"); shift 2 ;;
-        *)          POSITIONAL+=("$1"); shift ;;
+        --start)         START="$2"; shift 2 ;;
+        --end)           END="$2"; shift 2 ;;
+        --by-type)       BY_TYPE=1; shift ;;
+        --type)          TYPE_FILTERS+=("$2"); shift 2 ;;
+        --no-values)     NO_VALUES=1; shift ;;
+        --values-limit)  VALUES_LIMIT="$2"; shift 2 ;;
+        *)               POSITIONAL+=("$1"); shift ;;
     esac
 done
 
@@ -154,6 +180,30 @@ case "${POSITIONAL[0]}" in
             RAW=$(fetch_metrics_listing)
             # -e exits non-zero when the value is null/false; we want non-zero on missing.
             printf '%s' "$RAW" | jq -e --arg m "$METRIC" '.[$m] // error("metric not found in listing for the given time range: " + $m)'
+        elif [[ ${#POSITIONAL[@]} -eq 3 && "${POSITIONAL[2]}" == "describe" ]]; then
+            # Bundle metadata + tags + tag values into a single output. Replaces
+            # the typical 1+1+N round trips an agent would make to characterise
+            # an unfamiliar metric.
+            METRIC="${POSITIONAL[1]}"
+            RAW=$(fetch_metrics_listing)
+            META=$(printf '%s' "$RAW" | jq -e --arg m "$METRIC" '.[$m] // error("metric not found in listing for the given time range: " + $m)')
+            TAGS_JSON=$("$SCRIPT_DIR/axiom-api" "$DEPLOYMENT" GET "${BASE}/metrics/${METRIC}/tags?${TIME_PARAMS}")
+            if [[ "$NO_VALUES" -eq 1 ]]; then
+                # tags as flat array of names
+                jq -n --argjson m "$META" --argjson tags "$TAGS_JSON" '$m + {tags: $tags}'
+            else
+                # tags as object: { tag_name: [values…] }
+                VALUES_OBJ='{}'
+                while IFS= read -r tag; do
+                    [[ -z "$tag" ]] && continue
+                    VALUES=$("$SCRIPT_DIR/axiom-api" "$DEPLOYMENT" GET "${BASE}/metrics/${METRIC}/tags/${tag}/values?${TIME_PARAMS}")
+                    if [[ "$VALUES_LIMIT" -gt 0 ]]; then
+                        VALUES=$(printf '%s' "$VALUES" | jq --argjson n "$VALUES_LIMIT" '.[:$n]')
+                    fi
+                    VALUES_OBJ=$(jq -n --argjson o "$VALUES_OBJ" --arg t "$tag" --argjson v "$VALUES" '$o + {($t): $v}')
+                done < <(printf '%s' "$TAGS_JSON" | jq -r '.[]?')
+                jq -n --argjson m "$META" --argjson tags "$VALUES_OBJ" '$m + {tags: $tags}'
+            fi
         elif [[ ${#POSITIONAL[@]} -eq 3 && "${POSITIONAL[2]}" == "tags" ]]; then
             # List tags for a metric
             METRIC="${POSITIONAL[1]}"
@@ -163,6 +213,35 @@ case "${POSITIONAL[0]}" in
             METRIC="${POSITIONAL[1]}"
             TAG="${POSITIONAL[3]}"
             "$SCRIPT_DIR/axiom-api" "$DEPLOYMENT" GET "${BASE}/metrics/${METRIC}/tags/${TAG}/values?${TIME_PARAMS}"
+        elif [[ ${#POSITIONAL[@]} -eq 5 && "${POSITIONAL[2]}" == "tags" && "${POSITIONAL[4]}" == "type" ]]; then
+            # Probe the typing of a metric+tag by running `metrics-query` with
+            # `filter <tag> is <T>` for each candidate type. The type(s) that
+            # return non-empty `series` are present in the dataset for that
+            # metric+tag in the time window.
+            METRIC="${POSITIONAL[1]}"
+            TAG="${POSITIONAL[3]}"
+            PRESENT_JSON='[]'
+            for t in int float string bool; do
+                # Backtick-escape dataset / metric / tag names. The probe pipeline:
+                #   `<dataset>`:`<metric>` | filter `<tag>` is <T> | align to 5m using sum
+                # If <tag> is <T> matches no rows, the response has empty `series`.
+                PROBE_QUERY='`'"$DATASET"'`:`'"$METRIC"'` | filter `'"$TAG"'` is '"$t"' | align to 5m using sum'
+                RESPONSE=$("$SCRIPT_DIR/metrics-query" "$DEPLOYMENT" "$PROBE_QUERY" "$START" "$END" 2>/dev/null || echo '{}')
+                COUNT=$(printf '%s' "$RESPONSE" | jq -r '(.series // []) | length' 2>/dev/null || echo 0)
+                if [[ "$COUNT" -gt 0 ]]; then
+                    PRESENT_JSON=$(printf '%s' "$PRESENT_JSON" | jq --arg t "$t" '. + [$t]')
+                fi
+            done
+            jq -n --argjson present "$PRESENT_JSON" '
+                {
+                    type: (
+                        if   ($present | length) == 0 then "absent"
+                        elif ($present | length) == 1 then $present[0]
+                        else                                "mixed"
+                        end
+                    ),
+                    present_types: $present
+                }'
         else
             show_usage
         fi

--- a/skills/building-dashboards/scripts/metrics/metrics-info
+++ b/skills/building-dashboards/scripts/metrics/metrics-info
@@ -2,12 +2,30 @@
 # metrics-info: Discover metrics, tags, and tag values in a dataset
 #
 # Usage:
-#   metrics-info <deployment> <dataset> metrics [--start T --end T]
+#   metrics-info <deployment> <dataset> metrics [--by-type] [--type T]... [--start T --end T]
+#   metrics-info <deployment> <dataset> metrics <metric> info [--start T --end T]
 #   metrics-info <deployment> <dataset> tags    [--start T --end T]
 #   metrics-info <deployment> <dataset> tags <tag> values [--start T --end T]
 #   metrics-info <deployment> <dataset> metrics <metric> tags [--start T --end T]
 #   metrics-info <deployment> <dataset> metrics <metric> tags <tag> values [--start T --end T]
 #   metrics-info <deployment> <dataset> find-metrics <search-value> [--start T --end T]
+#
+# Metric metadata. The `metrics` listing returns a v2 payload where each entry
+# carries `type` (Gauge | CounterMonotonic | CounterNonMonotonic | Histogram),
+# `temporality` (Cumulative | Delta | null), and `unit` (UCUM string or null).
+# Use this metadata to choose the right MPL query shape (consult metrics-spec
+# for the exact operator names per type).
+#
+#   --by-type           Group the listing by `type` instead of returning a flat
+#                       name->meta object. Pure client-side reshape; no extra
+#                       server call.
+#   --type T            Filter the listing to entries whose `type` equals T.
+#                       Repeatable; multiple --type flags act as OR.
+#                       Composes with --by-type.
+#
+# The `metrics <metric> info` subcommand extracts a single metric's metadata
+# block ({type, temporality, unit}) from the bulk listing. Exits non-zero if
+# the metric is not present in the listing for the given time range.
 #
 # find-metrics searches TAG VALUES, not metric names. It returns metrics that have
 # a tag containing the given value. Use it when you know a specific entity name
@@ -18,9 +36,13 @@
 # For sparse metrics (sensors, batch jobs), try --start with a wider range (e.g. 7 days).
 #
 # Examples:
-#   metrics-info prod my-dataset metrics                    # List all metric names
-#   metrics-info prod my-dataset tags service.name values   # List values for a tag
-#   metrics-info prod my-dataset find-metrics "frontend"    # Find metrics with tag value "frontend"
+#   metrics-info prod my-dataset metrics                                # Raw listing
+#   metrics-info prod my-dataset metrics --by-type                      # Grouped by type
+#   metrics-info prod my-dataset metrics --type Histogram               # Only histograms
+#   metrics-info prod my-dataset metrics --type Gauge --type Histogram --by-type
+#   metrics-info prod my-dataset metrics http.server.duration info      # Single metric meta
+#   metrics-info prod my-dataset tags service.name values               # List values for a tag
+#   metrics-info prod my-dataset find-metrics "frontend"                # Find metrics with tag value "frontend"
 #   metrics-info prod my-dataset metrics http.server.duration tags --start 2025-06-01T00:00:00Z --end 2025-06-02T00:00:00Z
 
 set -euo pipefail
@@ -29,16 +51,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 show_usage() {
     echo "Usage:" >&2
-    echo "  metrics-info <deploy> <dataset> metrics" >&2
-    echo "  metrics-info <deploy> <dataset> tags" >&2
-    echo "  metrics-info <deploy> <dataset> tags <tag> values" >&2
+    echo "  metrics-info <deploy> <dataset> metrics [--by-type] [--type T]..." >&2
+    echo "  metrics-info <deploy> <dataset> metrics <metric> info" >&2
     echo "  metrics-info <deploy> <dataset> metrics <metric> tags" >&2
     echo "  metrics-info <deploy> <dataset> metrics <metric> tags <tag> values" >&2
+    echo "  metrics-info <deploy> <dataset> tags" >&2
+    echo "  metrics-info <deploy> <dataset> tags <tag> values" >&2
     echo "  metrics-info <deploy> <dataset> find-metrics <search-value>  (searches tag values, not metric names)" >&2
     echo "" >&2
     echo "Options:" >&2
-    echo "  --start T   Start time (RFC3339). Default: 24h ago" >&2
-    echo "  --end T     End time (RFC3339). Default: now" >&2
+    echo "  --start T    Start time (RFC3339). Default: 24h ago" >&2
+    echo "  --end T      End time (RFC3339). Default: now" >&2
+    echo "  --by-type    (metrics listing) Group entries by metric type" >&2
+    echo "  --type T     (metrics listing) Filter to type T (Gauge|CounterMonotonic|CounterNonMonotonic|Histogram). Repeatable." >&2
     exit 1
 }
 
@@ -51,15 +76,19 @@ fi
 
 shift 2
 
-# Collect positional args and parse --start/--end
+# Collect positional args and parse --start/--end and listing-view flags
 POSITIONAL=()
 START=""
 END=""
+BY_TYPE=0
+TYPE_FILTERS=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --start) START="$2"; shift 2 ;;
-        --end)   END="$2"; shift 2 ;;
-        *)       POSITIONAL+=("$1"); shift ;;
+        --start)    START="$2"; shift 2 ;;
+        --end)      END="$2"; shift 2 ;;
+        --by-type)  BY_TYPE=1; shift ;;
+        --type)     TYPE_FILTERS+=("$2"); shift 2 ;;
+        *)          POSITIONAL+=("$1"); shift ;;
     esac
 done
 
@@ -88,11 +117,43 @@ if [[ ${#POSITIONAL[@]} -eq 0 ]]; then
     show_usage
 fi
 
+# Fetch the bulk metrics listing (v2 payload with type/temporality/unit per metric).
+# Used directly by `metrics` and indirectly by `metrics <metric> info`.
+fetch_metrics_listing() {
+    AXIOM_ACCEPT="application/vnd.metrics-info.v2+json" "$SCRIPT_DIR/axiom-api" "$DEPLOYMENT" GET "${BASE}/metrics?${TIME_PARAMS}"
+}
+
 case "${POSITIONAL[0]}" in
     metrics)
         if [[ ${#POSITIONAL[@]} -eq 1 ]]; then
-            # List metrics
-            AXIOM_ACCEPT="application/vnd.metrics-info.v2+json" "$SCRIPT_DIR/axiom-api" "$DEPLOYMENT" GET "${BASE}/metrics?${TIME_PARAMS}"
+            # List metrics. Default behaviour returns the raw v2 payload byte-for-byte;
+            # --type / --by-type apply pure client-side reshapes via jq.
+            if [[ $BY_TYPE -eq 0 && ${#TYPE_FILTERS[@]} -eq 0 ]]; then
+                fetch_metrics_listing
+            else
+                RAW=$(fetch_metrics_listing)
+                JQ_FILTER='.'
+                if [[ ${#TYPE_FILTERS[@]} -gt 0 ]]; then
+                    # Build a JSON array of allowed types and filter entries.
+                    TYPES_JSON=$(printf '%s\n' "${TYPE_FILTERS[@]}" | jq -R . | jq -s .)
+                    JQ_FILTER='to_entries | map(select(.value.type as $vt | ($types | index($vt)))) | from_entries'
+                    if [[ $BY_TYPE -eq 1 ]]; then
+                        JQ_FILTER="$JQ_FILTER"' | to_entries | group_by(.value.type) | map({(.[0].value.type): (map({(.key): {temporality: .value.temporality, unit: .value.unit}}) | add)}) | add // {}'
+                    fi
+                    printf '%s' "$RAW" | jq --argjson types "$TYPES_JSON" "$JQ_FILTER"
+                else
+                    # --by-type only
+                    JQ_FILTER='to_entries | group_by(.value.type) | map({(.[0].value.type): (map({(.key): {temporality: .value.temporality, unit: .value.unit}}) | add)}) | add // {}'
+                    printf '%s' "$RAW" | jq "$JQ_FILTER"
+                fi
+            fi
+        elif [[ ${#POSITIONAL[@]} -eq 3 && "${POSITIONAL[2]}" == "info" ]]; then
+            # Single-metric metadata: {type, temporality, unit}. Derived client-side
+            # from the bulk listing because there is no per-metric metadata endpoint.
+            METRIC="${POSITIONAL[1]}"
+            RAW=$(fetch_metrics_listing)
+            # -e exits non-zero when the value is null/false; we want non-zero on missing.
+            printf '%s' "$RAW" | jq -e --arg m "$METRIC" '.[$m] // error("metric not found in listing for the given time range: " + $m)'
         elif [[ ${#POSITIONAL[@]} -eq 3 && "${POSITIONAL[2]}" == "tags" ]]; then
             # List tags for a metric
             METRIC="${POSITIONAL[1]}"

--- a/skills/building-dashboards/scripts/metrics/metrics-query
+++ b/skills/building-dashboards/scripts/metrics/metrics-query
@@ -1,33 +1,111 @@
 #!/usr/bin/env bash
 # metrics-query: Execute a metrics query against Axiom MetricsDB
 #
-# Usage: metrics-query <deployment> <mpl> <startTime> <endTime>
+# Usage: metrics-query [-p name=value]... <deployment> <mpl> <startTime> <endTime>
 #
 # Times: RFC3339 (e.g. 2025-01-01T00:00:00Z) or relative (e.g. now-1h, now-1d).
+#
+# Parameter values (-p / --param name=value, repeatable):
+#   For each MPL parameter declared in the query (e.g. `param $svc: string;`),
+#   pass the variable name without the leading `$` and an MPL literal as the
+#   value. The script applies the `param__` prefix to the key and forwards the
+#   value verbatim under the request body's `params` object — i.e. `-p svc=...`
+#   becomes `params.param__svc`. Callers are responsible for formatting the
+#   value as a valid MPL literal (per the metrics spec) and for any quoting
+#   the literal requires; the server parses it according to the variable's
+#   declared type. Parameters declared optional in the MPL (see metrics-spec)
+#   may be omitted; required parameters must be supplied or the server returns
+#   HTTP 400.
 #
 # Examples:
 #   metrics-query prod '`otel-metrics`:`http.server.duration` | align to 5m using avg | group by `endpoint` using sum' \
 #     '2025-06-01T00:00:00Z' '2025-06-02T00:00:00Z'
 #   metrics-query prod '`otel-metrics`:`http.server.duration` | align to 5m using avg' now-1h now
+#   # With parameters $svc: string and $window: Duration:
+#   metrics-query -p svc='"frontend"' -p window='5m' prod \
+#     'param $svc: string; param $window: Duration; `otel-metrics`:`http.server.duration` | where `service.name` == $svc | align to $window using avg' \
+#     now-1h now
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-DEPLOYMENT="${1:-}"
-MPL="${2:-}"
-START_TIME="${3:-}"
-END_TIME="${4:-}"
+PARAMS=()
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -p|--param)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: $1 requires an argument of the form name=value" >&2
+                exit 1
+            fi
+            PARAMS+=("$2")
+            shift 2
+            ;;
+        --param=*)
+            PARAMS+=("${1#--param=}")
+            shift
+            ;;
+        --)
+            shift
+            while [[ $# -gt 0 ]]; do POSITIONAL+=("$1"); shift; done
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+
+DEPLOYMENT="${POSITIONAL[0]:-}"
+MPL="${POSITIONAL[1]:-}"
+START_TIME="${POSITIONAL[2]:-}"
+END_TIME="${POSITIONAL[3]:-}"
 
 if [[ -z "$DEPLOYMENT" || -z "$MPL" || -z "$START_TIME" || -z "$END_TIME" ]]; then
-    echo "Usage: metrics-query <deployment> <mpl> <startTime> <endTime>" >&2
+    echo "Usage: metrics-query [-p name=value]... <deployment> <mpl> <startTime> <endTime>" >&2
     echo "" >&2
     echo "Times: RFC3339 (e.g. 2025-01-01T00:00:00Z) or relative (e.g. now-1h, now-1d)." >&2
+    echo "" >&2
+    echo "-p / --param name=value (repeatable): supply an MPL parameter value." >&2
+    echo "  name  - variable name without the leading \$ (e.g. 'svc' for \$svc)." >&2
+    echo "  value - MPL literal, forwarded verbatim under params.param__<name>." >&2
     exit 1
 fi
 
+# Validate and split params into parallel name/value arrays.
+PARAM_NAMES=()
+PARAM_VALUES=()
+if [[ ${#PARAMS[@]} -gt 0 ]]; then
+    for entry in "${PARAMS[@]}"; do
+        if [[ "$entry" != *"="* ]]; then
+            echo "Error: -p expects name=value, got: $entry" >&2
+            exit 1
+        fi
+        name="${entry%%=*}"
+        value="${entry#*=}"
+        if [[ -z "$name" ]]; then
+            echo "Error: -p name is empty in: $entry" >&2
+            exit 1
+        fi
+        if [[ "${name:0:1}" == "\$" ]]; then
+            echo "Error: -p name must not include the leading \$ (got: $name); pass the bare variable name" >&2
+            exit 1
+        fi
+        PARAM_NAMES+=("$name")
+        PARAM_VALUES+=("$value")
+    done
+fi
+
 # Extract dataset name from MPL: `dataset`:`metric` ... or dataset:`metric` ...
-DATASET=$(echo "$MPL" | sed 's/`//g' | cut -d: -f1 | tr -d '[:space:]')
+# Strip leading `param <name>: <type>;` declarations first so their `:` doesn't
+# get mistaken for the dataset:metric separator.
+PIPELINE="$MPL"
+while [[ "$PIPELINE" =~ ^[[:space:]]*[Pp]aram[[:space:]] ]]; do
+    if [[ "$PIPELINE" != *";"* ]]; then break; fi
+    PIPELINE="${PIPELINE#*;}"
+done
+DATASET=$(echo "$PIPELINE" | sed 's/`//g' | cut -d: -f1 | tr -d '[:space:]')
 
 QUERY_EDGE_DEPLOYMENT=""
 if [[ -n "$DATASET" ]]; then
@@ -46,11 +124,21 @@ JQ_ARGS=(
     --arg startT "$START_TIME"
     --arg endT "$END_TIME"
 )
-JQ_EXPR='{"apl": $apl, "startTime": $startT, "endTime": $endT}'
+JQ_EXPR='{apl: $apl, startTime: $startT, endTime: $endT}'
 
 if [[ -n "$QUERY_EDGE_DEPLOYMENT" ]]; then
     JQ_ARGS+=(--arg edgeDeployment "$QUERY_EDGE_DEPLOYMENT")
-    JQ_EXPR='{"apl": $apl, "startTime": $startT, "endTime": $endT, "queryEdgeDeployment": $edgeDeployment}'
+    JQ_EXPR="$JQ_EXPR + {queryEdgeDeployment: \$edgeDeployment}"
+fi
+
+if [[ ${#PARAM_NAMES[@]} -gt 0 ]]; then
+    PARAMS_EXPR=""
+    for i in "${!PARAM_NAMES[@]}"; do
+        JQ_ARGS+=(--arg "pn$i" "${PARAM_NAMES[$i]}" --arg "pv$i" "${PARAM_VALUES[$i]}")
+        if [[ -n "$PARAMS_EXPR" ]]; then PARAMS_EXPR+=" + "; fi
+        PARAMS_EXPR+="{(\"param__\" + \$pn$i): \$pv$i}"
+    done
+    JQ_EXPR="$JQ_EXPR + {params: ($PARAMS_EXPR)}"
 fi
 
 BODY=$(jq -n "${JQ_ARGS[@]}" "$JQ_EXPR")

--- a/skills/building-dashboards/scripts/metrics/mpl-validate-chart
+++ b/skills/building-dashboards/scripts/metrics/mpl-validate-chart
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# mpl-validate-chart: Validate a chart MPL pipeline by simulating the
+# dashboard runtime's $__interval injection.
+#
+# Why this exists:
+#   The dashboard runtime auto-declares `param $__interval: Duration;` on
+#   every chart query and supplies its value via the request body. The
+#   plain `metrics-query` script does NOT — so testing a chart query
+#   directly with `metrics-query` fails with `The param $__interval is not
+#   defined`. This wrapper does the dance.
+#
+#   It also rejects inline time ranges (`[1h..]`, `[30d..]`, etc.) up
+#   front, with a clear error. Inline ranges deploy fine but render with
+#   `AST Error (Time is provided both in the query and as a parameter)` at
+#   runtime, because the dashboard always passes start/end via the API.
+#
+# Usage:
+#   mpl-validate-chart <deployment> '<MPL>' [start] [end] [--interval <DUR>]
+#
+# Defaults:
+#   start    = now-1h
+#   end      = now
+#   interval = 5m
+#
+# Examples:
+#   mpl-validate-chart staging \
+#     '`k8s-metrics-staging`:apiserver_request_total
+#       | where `service.name` == "apiserver"
+#       | align to $__interval using prom::rate
+#       | group by code using sum'
+#
+#   # Override the simulated interval
+#   mpl-validate-chart --interval 1h staging \
+#     '`k8s-metrics-staging`:process_resident_memory_bytes
+#       | align to $__interval using avg'
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+METRICS_QUERY="$SCRIPT_DIR/metrics-query"
+
+INTERVAL="5m"
+DEPLOYMENT=""
+MPL=""
+START="now-1h"
+END="now"
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --interval) INTERVAL="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,/^set -euo pipefail/p' "$0" | sed 's/^# \?//' | sed '$d'
+            exit 0
+            ;;
+        --) shift; POSITIONAL+=("$@"); break ;;
+        --*) echo "Error: unknown flag '$1'" >&2; exit 1 ;;
+        *) POSITIONAL+=("$1"); shift ;;
+    esac
+done
+
+if [[ ${#POSITIONAL[@]} -lt 2 ]]; then
+    echo "Usage: mpl-validate-chart <deployment> '<MPL>' [start] [end] [--interval <DUR>]" >&2
+    exit 1
+fi
+
+DEPLOYMENT="${POSITIONAL[0]}"
+MPL="${POSITIONAL[1]}"
+START="${POSITIONAL[2]:-$START}"
+END="${POSITIONAL[3]:-$END}"
+
+# --- Reject inline time ranges --------------------------------------------
+#
+# MPL inline ranges look like `[1h..]`, `[30d..5m]`, `[2025-01-01T..+1h]`,
+# `[1747077736..]`, etc. — `..` inside `[]`. MPL doesn't otherwise use `[]`
+# at the source level (no list/array literals at the top of the syntax),
+# so this regex is safe.
+
+if printf '%s' "$MPL" | grep -qE '\[[^]]*\.\.[^]]*\]'; then
+    cat >&2 <<EOF
+Error: inline time range detected in MPL (e.g. \`[1h..]\` or \`[30d..]\`).
+
+Dashboard chart queries cannot use inline time ranges — the dashboard
+runtime always supplies start/end via the API, and an inline range
+collides with that, surfacing as:
+
+    AST Error (Time is provided both in the query and as a parameter)
+
+Remove the inline range. The dashboard time picker (or the dashboard's
+\`timeWindowStart\` / \`timeWindowEnd\`) controls the window. Use
+\`align to \$__interval using …\` for bucketing.
+EOF
+    exit 1
+fi
+
+# --- Auto-inject `param $__interval: Duration;` if needed ----------------
+#
+# Only inject and pass `-p __interval=…` when the query actually
+# references `$__interval`. Otherwise the server returns the warning
+# "These params were provided but not declared: $__interval" — confusing
+# noise on a query that has nothing to do with the variable.
+
+USES_INTERVAL=0
+WRAPPED="$MPL"
+if printf '%s' "$MPL" | grep -qF '$__interval'; then
+    USES_INTERVAL=1
+    if ! printf '%s' "$MPL" | grep -qE 'param[[:space:]]+\$__interval'; then
+        WRAPPED=$(printf 'param $__interval: Duration;\n%s' "$MPL")
+    fi
+fi
+
+# --- Forward to metrics-query --------------------------------------------
+
+if [[ $USES_INTERVAL -eq 1 ]]; then
+    exec "$METRICS_QUERY" -p "__interval=$INTERVAL" "$DEPLOYMENT" "$WRAPPED" "$START" "$END"
+else
+    exec "$METRICS_QUERY" "$DEPLOYMENT" "$WRAPPED" "$START" "$END"
+fi

--- a/skills/building-dashboards/scripts/metrics/resolve-url
+++ b/skills/building-dashboards/scripts/metrics/resolve-url
@@ -10,6 +10,13 @@
 #   cloud.us-east-1.aws    → https://us-east-1.aws.edge.axiom.co
 #   cloud.eu-central-1.aws → https://eu-central-1.aws.edge.axiom.co
 #   (null/empty)           → falls back to deployment URL from config
+#
+# Environment overrides:
+#   AXIOM_URL_OVERRIDE     → if set, returned verbatim and no API/cache
+#                            lookup is performed. Mirrors axiom-api's own
+#                            AXIOM_URL_OVERRIDE handling so callers can
+#                            point both scripts at a non-default edge with
+#                            a single env var.
 
 set -euo pipefail
 
@@ -21,6 +28,14 @@ DATASET="${2:-}"
 if [[ -z "$DEPLOYMENT" || -z "$DATASET" ]]; then
     echo "Usage: resolve-url <deployment> <dataset>" >&2
     exit 1
+fi
+
+# Honour an explicit override before touching the cache or the API.
+# Skipping the cache write keeps session-scoped overrides from leaking
+# into later invocations that don't set the env var.
+if [[ -n "${AXIOM_URL_OVERRIDE:-}" ]]; then
+    echo "$AXIOM_URL_OVERRIDE"
+    exit 0
 fi
 
 CONFIG_FILE="$HOME/.axiom.toml"
@@ -51,7 +66,7 @@ extract_value() {
 
 FALLBACK_URL=$(extract_value "url")
 
-EDGE_DEPLOYMENT=$("$SCRIPT_DIR/axiom-api" "$DEPLOYMENT" GET /v1/datasets \
+EDGE_DEPLOYMENT=$("$SCRIPT_DIR/axiom-api" "$DEPLOYMENT" GET /v2/datasets \
     | jq -r --arg name "$DATASET" '.[] | select(.name == $name) | .edgeDeployment // empty')
 
 RESOLVED_URL=""

--- a/skills/building-dashboards/scripts/metrics/unit-for
+++ b/skills/building-dashboards/scripts/metrics/unit-for
@@ -28,8 +28,8 @@
 #
 # This script is intended for Statistic charts. TimeSeries / Heatmap / Pie /
 # Table / LogStream reject the `unit` enum on create; they accept
-# `customUnits` at the API level but visual rendering is unverified. Always
-# also encode the unit in the chart name (e.g. "Latency (ms)").
+# `customUnits` at the API level. Always also encode the unit in the chart
+# name (e.g. "Latency (ms)") so the header is self-describing.
 # See reference/chart-config.md § Unit Configuration.
 #
 # Examples:
@@ -43,11 +43,11 @@
 #   unit-for ""        # -> {"unit":"Auto"}
 #   unit-for "1"       # -> {"unit":"Auto"}
 #
-# Note: "%" emits BOTH `unit: "Percent100"` and `customUnits: "%"`. Verified
-# May 2026: `Percent100` alone scales the value to 0-100 but does not paint
-# the percent sign; `customUnits: "%"` is what produces the "%" suffix.
-# The same pairing applies if you've written your MPL to multiply a 0-1
-# ratio by 100 and want a percent display.
+# Note: "%" emits BOTH `unit: "Percent100"` and `customUnits: "%"`.
+# `Percent100` alone scales the value to 0-100 but does not paint the percent
+# sign; `customUnits: "%"` is what produces the "%" suffix. The same pairing
+# applies if you've written your MPL to multiply a 0-1 ratio by 100 and want
+# a percent display.
 
 set -euo pipefail
 

--- a/skills/building-dashboards/scripts/metrics/unit-for
+++ b/skills/building-dashboards/scripts/metrics/unit-for
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# unit-for: Map a metric's UCUM/OTel unit string to an Axiom chart unit config.
+#
+# Usage:
+#   unit-for <unit-string>
+#
+# Emits a JSON object on stdout suitable for splicing into a Statistic chart
+# config alongside `name` and `query`. Two output shapes:
+#
+#   {"unit":"<enum>"}                          # mapped to an Axiom unit enum
+#   {"unit":"Auto","customUnits":"<verbatim>"} # not in the enum; pass through
+#                                              # the raw unit as a suffix
+#
+# Empty input, missing input, and "1" (OTel dimensionless) all return
+# {"unit":"Auto"} with no customUnits.
+#
+# By design, the following UCUM codes are NOT auto-mapped because they are
+# ambiguous or context-dependent. They fall through to customUnits verbatim;
+# the dashboard author can override if they know the intent:
+#   - "m"  : could be metres or minutes
+#   - "B"  : could be Bel or shorthand-bytes (use "By" for bytes)
+#   - "1"  : OTel "dimensionless"; could be a 0-1 ratio or a unitless count.
+#            Defaults to Auto with no suffix. NOTE: if it IS a 0-1 ratio, do
+#            NOT use the `Percent` enum -- it does not auto-multiply by 100
+#            and 1.0 renders as bare "1". Multiply by 100 in MPL
+#            (`| map * 100`) and set `unit: "Percent100"` on the chart.
+#            See reference/metrics-mpl.md § Percentages and ratios.
+#
+# This script is intended for Statistic charts. TimeSeries / Heatmap / Pie /
+# Table / LogStream reject the `unit` enum on create; they accept
+# `customUnits` at the API level but visual rendering is unverified. Always
+# also encode the unit in the chart name (e.g. "Latency (ms)").
+# See reference/chart-config.md § Unit Configuration.
+#
+# Examples:
+#   unit-for "s"       # -> {"unit":"TimeSec"}
+#   unit-for "ms"      # -> {"unit":"TimeMS"}
+#   unit-for "By"      # -> {"unit":"Byte"}
+#   unit-for "%"       # -> {"unit":"Percent100","customUnits":"%"}
+#   unit-for "EUR"     # -> {"unit":"CurrencyEUR"}
+#   unit-for "Cel"     # -> {"unit":"Auto","customUnits":"Cel"}
+#   unit-for "kW.h"    # -> {"unit":"Auto","customUnits":"kW.h"}
+#   unit-for ""        # -> {"unit":"Auto"}
+#   unit-for "1"       # -> {"unit":"Auto"}
+#
+# Note: "%" emits BOTH `unit: "Percent100"` and `customUnits: "%"`. Verified
+# May 2026: `Percent100` alone scales the value to 0-100 but does not paint
+# the percent sign; `customUnits: "%"` is what produces the "%" suffix.
+# The same pairing applies if you've written your MPL to multiply a 0-1
+# ratio by 100 and want a percent display.
+
+set -euo pipefail
+
+UNIT="${1-}"
+
+# Mapping table: UCUM/OTel unit code -> Axiom chart unit enum value.
+# Keep additions in sync with the available units listed in
+# reference/chart-config.md ("Available Units").
+jq -n --arg u "$UNIT" '
+  {
+    # Time
+    "s": "TimeSec", "seconds": "TimeSec", "sec": "TimeSec",
+    "ms": "TimeMS", "milliseconds": "TimeMS",
+    "us": "TimeUS", "microseconds": "TimeUS", "µs": "TimeUS",
+    "ns": "TimeNS", "nanoseconds": "TimeNS",
+    "min": "TimeMin",
+    "h": "TimeHour", "hour": "TimeHour", "hours": "TimeHour",
+    "d": "TimeDay", "day": "TimeDay", "days": "TimeDay",
+    # Data sizes (UCUM uses By for byte; B is Bel and is intentionally NOT mapped)
+    "By": "Byte", "bytes": "Byte",
+    "KBy": "Kilobyte", "KiBy": "Kilobyte",
+    "MBy": "Megabyte", "MiBy": "Megabyte",
+    "GBy": "Gigabyte", "GiBy": "Gigabyte",
+    # Data rates
+    "By/s": "BytesSec", "bytes/s": "BytesSec",
+    "bit/s": "BitsSec",
+    # Percent (0-100). For OTel 0-1 ratio metrics, multiply by 100 in MPL
+    # (`| map * 100`) and use Percent100 -- the `Percent` enum does NOT
+    # auto-multiply and renders 1.0 as bare "1".
+    # Note: "%" gets special handling below to emit both `unit: "Percent100"`
+    # AND `customUnits: "%"` because Percent100 alone does not paint the suffix.
+    "%": "Percent100",
+    # Currency (ISO 4217 codes)
+    "USD": "CurrencyUSD",
+    "EUR": "CurrencyEUR",
+    "GBP": "CurrencyGBP",
+    "JPY": "CurrencyJPY",
+    "INR": "CurrencyINR",
+    "CAD": "CurrencyCAD",
+    "AUD": "CurrencyAUD",
+    "CZK": "CurrencyCZK",
+    "PLN": "CurrencyPLN"
+  } as $table
+  | $table[$u] as $enum
+  | if ($u == "" or $u == null or $u == "1") then {unit: "Auto"}
+    elif $u == "%" then {unit: "Percent100", customUnits: "%"}
+    elif $enum then {unit: $enum}
+    else {unit: "Auto", customUnits: $u}
+    end
+'

--- a/skills/building-dashboards/tests/unit-for.sh
+++ b/skills/building-dashboards/tests/unit-for.sh
@@ -65,7 +65,10 @@ check "rate:By/s"         "By/s"          '{"unit":"BytesSec"}'
 check "rate:bit/s"        "bit/s"         '{"unit":"BitsSec"}'
 
 # Percent
-check "percent"           "%"             '{"unit":"Percent100"}'
+# Special case: "%" emits BOTH `unit` and `customUnits` because Percent100
+# alone scales the value but does not paint the suffix. See unit-for header
+# and reference/chart-config.md § Unit Configuration.
+check "percent"           "%"             '{"unit":"Percent100","customUnits":"%"}'
 
 # Currency (a representative subset)
 check "currency:EUR"      "EUR"           '{"unit":"CurrencyEUR"}'

--- a/skills/building-dashboards/tests/unit-for.sh
+++ b/skills/building-dashboards/tests/unit-for.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# tests/unit-for.sh — golden tests for scripts/metrics/unit-for
+#
+# Run from anywhere:
+#   skills/building-dashboards/tests/unit-for.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/scripts/metrics/unit-for"
+
+if [[ ! -x "$SCRIPT" ]]; then
+    echo "FAIL: $SCRIPT is not executable" >&2
+    exit 2
+fi
+
+PASS=0
+FAIL=0
+
+# Compare two JSON blobs as sorted objects so key order doesn't matter.
+check() {
+    local label="$1" input="$2" expected="$3"
+    local actual
+    if actual=$("$SCRIPT" "$input" 2>&1); then
+        :
+    else
+        echo "FAIL [$label]: '$input' -> script errored: $actual"
+        FAIL=$((FAIL+1))
+        return
+    fi
+    local actual_sorted expected_sorted
+    actual_sorted=$(echo "$actual" | jq -S .)
+    expected_sorted=$(echo "$expected" | jq -S .)
+    if [[ "$actual_sorted" == "$expected_sorted" ]]; then
+        PASS=$((PASS+1))
+    else
+        echo "FAIL [$label]: '$input'"
+        echo "  expected: $expected_sorted"
+        echo "  actual:   $actual_sorted"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+# Time units
+check "time:s"            "s"             '{"unit":"TimeSec"}'
+check "time:seconds"      "seconds"       '{"unit":"TimeSec"}'
+check "time:ms"           "ms"            '{"unit":"TimeMS"}'
+check "time:us"           "us"            '{"unit":"TimeUS"}'
+check "time:ns"           "ns"            '{"unit":"TimeNS"}'
+check "time:min"          "min"           '{"unit":"TimeMin"}'
+check "time:h"            "h"             '{"unit":"TimeHour"}'
+check "time:hour"         "hour"          '{"unit":"TimeHour"}'
+check "time:d"            "d"             '{"unit":"TimeDay"}'
+
+# Bytes
+check "bytes:By"          "By"            '{"unit":"Byte"}'
+check "bytes:bytes"       "bytes"         '{"unit":"Byte"}'
+check "bytes:KBy"         "KBy"           '{"unit":"Kilobyte"}'
+check "bytes:MBy"         "MBy"           '{"unit":"Megabyte"}'
+check "bytes:GBy"         "GBy"           '{"unit":"Gigabyte"}'
+check "bytes:KiBy"        "KiBy"          '{"unit":"Kilobyte"}'
+
+# Rates
+check "rate:By/s"         "By/s"          '{"unit":"BytesSec"}'
+check "rate:bit/s"        "bit/s"         '{"unit":"BitsSec"}'
+
+# Percent
+check "percent"           "%"             '{"unit":"Percent100"}'
+
+# Currency (a representative subset)
+check "currency:EUR"      "EUR"           '{"unit":"CurrencyEUR"}'
+check "currency:USD"      "USD"           '{"unit":"CurrencyUSD"}'
+check "currency:JPY"      "JPY"           '{"unit":"CurrencyJPY"}'
+
+# Custom (unmapped) — these are real units observed in the homeassistant-metrics
+# dataset on the axiom deployment, so the tests double as regression coverage
+# for the fallback path against real-world inputs.
+check "custom:Cel"        "Cel"           '{"unit":"Auto","customUnits":"Cel"}'
+check "custom:kW.h"       "kW.h"          '{"unit":"Auto","customUnits":"kW.h"}'
+check "custom:[ppm]"      "[ppm]"         '{"unit":"Auto","customUnits":"[ppm]"}'
+check "custom:m3/h"       "m3/h"          '{"unit":"Auto","customUnits":"m3/h"}'
+check "custom:lx"         "lx"            '{"unit":"Auto","customUnits":"lx"}'
+check "custom:ug/m3"      "ug/m3"         '{"unit":"Auto","customUnits":"ug/m3"}'
+check "custom:A"          "A"             '{"unit":"Auto","customUnits":"A"}'
+check "custom:V"          "V"             '{"unit":"Auto","customUnits":"V"}'
+
+# Ambiguous — by design, NOT auto-mapped. These properties are documented in
+# unit-for's header and in reference/metrics-mpl.md; a regression here means
+# we have unintentionally introduced a footgun.
+check "ambiguous:m"       "m"             '{"unit":"Auto","customUnits":"m"}'
+check "ambiguous:B"       "B"             '{"unit":"Auto","customUnits":"B"}'
+
+# Special sentinels
+check "sentinel:1"        "1"             '{"unit":"Auto"}'
+check "sentinel:empty"    ""              '{"unit":"Auto"}'
+
+# Missing arg should behave like empty string (bash ${1-})
+if MISSING_OUT=$("$SCRIPT" 2>&1); then
+    actual_sorted=$(echo "$MISSING_OUT" | jq -S .)
+    expected_sorted=$(echo '{"unit":"Auto"}' | jq -S .)
+    if [[ "$actual_sorted" == "$expected_sorted" ]]; then
+        PASS=$((PASS+1))
+    else
+        echo "FAIL [missing-arg]: expected $expected_sorted, got $actual_sorted"
+        FAIL=$((FAIL+1))
+    fi
+else
+    echo "FAIL [missing-arg]: script errored: $MISSING_OUT"
+    FAIL=$((FAIL+1))
+fi
+
+echo "---"
+echo "Passed: $PASS  Failed: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/skills/controlling-costs/reference/dashboard-panels.md
+++ b/skills/controlling-costs/reference/dashboard-panels.md
@@ -87,7 +87,7 @@ To add a horizontal contract line to time series:
 
 ### Adjusting Time Range
 
-Default: 30 days. Adjust in dashboard settings or per-panel with `overrideDashboardTimeRange`.
+Default: 30 days. Adjust via the dashboard `timeWindowStart`/`timeWindowEnd` (top-level fields) or the dashboard time picker. Per-panel time override is UI-only — there is no API field for it. (`overrideDashboardTimeRange` is not a real chart-create option: it is silently dropped on data charts and rejected on `Note`. See [building-dashboards § Fields Rejected on Create](../../building-dashboards/reference/chart-config.md#fields-rejected-on-create-cross-chart).)
 
 ### Color Scheme
 

--- a/skills/controlling-costs/templates/dashboard.json
+++ b/skills/controlling-costs/templates/dashboard.json
@@ -136,7 +136,6 @@
       "errorThresholdValue": "25",
       "id": "wow-change",
       "name": "Week-over-Week",
-      "overrideDashboardTimeRange": true,
       "query": {
         "apl": "declare query_parameters (org_filter:string = \"\", dataset_filter:string = \"\");\n['axiom-audit']\n| where _time between (ago(14d) .. now())\n| where action == 'usageCalculated'\n| where isempty(org_filter) or ['resource.id'] == org_filter\n| where isempty(dataset_filter) or tostring(['properties.dataset']) == dataset_filter\n| summarize this_week = sumif(['properties.hourly_ingest_bytes'], _time >= ago(7d)), last_week = sumif(['properties.hourly_ingest_bytes'], _time < ago(7d) and _time >= ago(14d))\n| extend ['WoW %'] = iff(last_week == 0, real(null), round(100.0 * (this_week - last_week) / last_week, 1))\n| project ['WoW %']"
       },
@@ -158,8 +157,6 @@
       "id": "ingest-by-dataset-ts",
       "name": "Daily Ingest by Dataset (GB)",
       "numSeries": 1,
-      "overrideDashboardCompareAgainst": false,
-      "overrideDashboardTimeRange": false,
       "query": {
         "apl": "declare query_parameters (org_filter:string = \"\", dataset_filter:string = \"\");\n[\"axiom-audit\"]\n| where action == \"usageCalculated\"\n| where isempty(org_filter) or [\"resource.id\"] == org_filter\n| where isempty(dataset_filter) or tostring([\"properties.dataset\"]) == dataset_filter\n| summarize [\"GB\"] = round(sum([\"properties.hourly_ingest_bytes\"]) / 1000000000, 1) by bin(_time, 1d), Dataset = tostring([\"properties.dataset\"])",
         "endTime": "",

--- a/skills/query-metrics/SKILL.md
+++ b/skills/query-metrics/SKILL.md
@@ -3,295 +3,144 @@ name: query-metrics
 description: Runs metrics queries against Axiom MetricsDB via scripts. Discovers available metrics, tags, and tag values. Use when asked to query metrics, explore metric datasets, check metric values, or investigate OTel metrics data.
 ---
 
-> **CRITICAL:** ALL script paths are relative to this skill's folder. Run them with full path (e.g., `scripts/metrics-query`).
-
 # Querying Axiom Metrics
 
-Query OpenTelemetry metrics stored in Axiom's MetricsDB.
+All script paths are relative to this skill's folder; invoke as `scripts/<name>`. The target dataset must be of kind `otel:metrics:v1`.
 
-## Setup
-
-Run `scripts/setup` to check requirements (curl, jq, ~/.axiom.toml).
-
-Config in `~/.axiom.toml` (shared with axiom-sre):
-```toml
-[deployments.prod]
-url = "https://api.axiom.co"
-token = "xaat-your-token"
-org_id = "your-org-id"
-```
-
-The target dataset must be of kind `otel:metrics:v1`.
-
----
-
-## Discovering Datasets
-
-List all datasets in a deployment:
-
-```bash
-scripts/datasets <deployment>
-```
-
-Filter to only metrics datasets:
-
-```bash
-scripts/datasets <deployment> --kind otel:metrics:v1
-```
-
-This returns each dataset's `name`, `edgeDeployment`, and `kind`. Use the dataset name in subsequent `metrics-info` and `metrics-query` calls.
-
----
-
-## Edge Deployment Resolution
-
-Datasets can live in different edge deployments (e.g., `us-east-1` vs `eu-central-1`). The scripts **automatically resolve** the correct regional edge URL before querying. No manual configuration is needed — `metrics-info` and `metrics-query` detect the dataset's edge deployment and route requests to the right endpoint.
-
-| Edge Deployment | Edge Endpoint |
-|---|---|
-| `cloud.us-east-1.aws` | `https://us-east-1.aws.edge.axiom.co` |
-| `cloud.eu-central-1.aws` | `https://eu-central-1.aws.edge.axiom.co` |
-
-If resolution fails or the edge deployment is unknown, requests fall back to the deployment URL in `~/.axiom.toml`.
-
----
-
-## Learning the Metrics Query Syntax
-
-> **CRITICAL:** You MUST run `metrics-spec` before composing your first query in a session. NEVER guess MPL syntax — it changes over time and the spec is the only source of truth.
-
-```bash
-scripts/metrics-spec <deployment> <dataset>
-```
-
-Re-consult the spec when using an unfamiliar operator, when a query returns a syntax error, or when constructing histogram/multi-metric queries.
-
----
+Setup, prerequisites, and `~/.axiom.toml` configuration: see `README.md`. Edge-deployment routing is automatic — the scripts read each dataset's `edgeDeployment` and route to the right regional endpoint without configuration.
 
 ## Workflow
 
-1. **List datasets**: Run `scripts/datasets <deployment>` to see available datasets and their edge deployments
-2. **Fetch the spec**: Run `scripts/metrics-spec <deployment> <dataset>` — **this step is mandatory before writing any query**
-3. **Discover and classify metrics**: List available metrics via `scripts/metrics-info <deployment> <dataset> metrics`. The response carries each metric's `type`, `temporality`, and `unit` — read these before composing a query (see [Choosing a query shape from metric metadata](#choosing-a-query-shape-from-metric-metadata) below).
-4. **Explore tags**: List tags and tag values to understand filtering options. If metrics listing fails, use tags and tag values to identify relevant entities, then use those to list metrics for specific tags.
-5. **Write and execute query**: Compose a metrics query and run it via `scripts/metrics-query`
-6. **Iterate**: Refine filters, aggregations, and groupings based on results
+1. `scripts/datasets <deploy> --kind otel:metrics:v1` — list metrics datasets.
+2. `scripts/metrics-spec <deploy> <dataset>` — **required** before composing any query. MPL evolves; the spec is the source of truth.
+3. `scripts/metrics-info <deploy> <dataset> metrics` — list metrics with `{type, temporality, unit}` metadata. Read this before writing the query (see [Choosing a Query Shape](#choosing-a-query-shape)).
+4. `scripts/metrics-info <deploy> <dataset> tags [<tag> values]` — explore filter dimensions.
+5. `scripts/metrics-query <deploy> '<MPL>' <start> <end>` — execute. Iterate.
 
-If the user provides a specific service, host, or entity name to search for, use `find-metrics` to locate matching metrics:
-```bash
-scripts/metrics-info <deployment> <dataset> find-metrics "frontend"
-```
-Do NOT use `find-metrics` as a general discovery step — it requires a known search value. After `find-metrics` returns candidates, fetch each one's metadata with `metrics-info … metrics <metric> info` before writing a query against it.
+If the user names a specific entity (service, host, …), `scripts/metrics-info <deploy> <dataset> find-metrics "<value>"` finds the metrics carrying it. `find-metrics` searches **tag values**, not metric names — don't use it for general discovery.
 
----
+## Choosing a Query Shape
 
-## Choosing a query shape from metric metadata
+The `metrics-info` listing returns each metric's `{type, temporality, unit}`. Read these before composing — never assume a metric is a simple scalar.
 
-The `metrics` listing returns a v2 payload where each metric carries three fields that should drive how you write the MPL query. **Always read this metadata before composing a query — never assume a metric is a simple scalar.**
+| Field | Values | Drives |
+|---|---|---|
+| `type` | `Gauge`, `CounterMonotonic`, `CounterNonMonotonic`, `Histogram` | Required pre-aggregation operators. |
+| `temporality` | `Cumulative`, `Delta`, `null` | Whether counter values are running totals or per-interval deltas. `null` is normal for Gauges. |
+| `unit` | UCUM string (`Cel`, `kW.h`, `s`, `%`, `[ppm]`, …) or `null` | Display unit; preserve when reporting results. |
 
-| Field | Values | What it tells you |
-|-------|--------|-------------------|
-| `type` | `Gauge`, `CounterMonotonic`, `CounterNonMonotonic`, `Histogram` | The kind of instrument; determines required pre-aggregation operators |
-| `temporality` | `Cumulative`, `Delta`, or `null` | Whether counter values are running totals or per-interval deltas. `null` is normal for Gauges. |
-| `unit` | UCUM-style string (`Cel`, `kW.h`, `s`, `%`, `[ppm]`, …) or `null` | Display unit; preserve when reporting results to the user |
+Rules per type (consult `metrics-spec` for exact operator names — they evolve):
 
-**Rules of thumb (consult `metrics-spec` for the exact operator names — they may evolve):**
+- **Gauge** — instantaneous value. Align directly with `avg`/`min`/`max`/`sum`. Don't apply a rate; you'd be averaging meaningless deltas of an instantaneous value.
+- **CounterMonotonic + Cumulative** — running total (resets aside). The raw values are rarely what you want. Convert to a per-second rate first, **then** align/aggregate.
+- **CounterMonotonic + Delta** — already per-interval. Sum/align without a rate step.
+- **CounterNonMonotonic** — can go up or down (queue depth, balance). Intent is ambiguous: rate, delta, or current value all make sense for different questions. **Ask the user** before picking one.
+- **Histogram** — not a scalar. `align using avg` produces nonsense. Use the bucket/quantile operators from `metrics-spec`.
+- **`temporality: null`** — "not applicable for this instrument type" (the norm for Gauges), not "missing data".
 
-- **Gauge** — instantaneous value. Align directly with `avg`/`min`/`max`/`sum`. Do **not** apply a rate operator; you'd be averaging meaningless deltas of an instantaneous value.
-- **CounterMonotonic + Cumulative** — running total that only goes up (resets aside). The raw values are almost never what the user wants. Convert to a per-second rate first, **then** align/aggregate. Look up the rate operator in the spec's standard library.
-- **CounterMonotonic + Delta** — already per-interval; can be summed/aligned without a rate step.
-- **CounterNonMonotonic** — can go up or down (e.g. queue depth, balance). Intent is ambiguous: rate, delta, or current value all make sense for different questions. **Ask the user what they want to see** before picking one.
-- **Histogram** — not a scalar. Direct `align using avg` will not give you what you expect. Consult the histogram section of `metrics-spec` for quantile/bucket operators.
-- **`temporality: null`** means "not applicable for this instrument type" (the norm for Gauges), not "missing data".
-
-**Reporting results.** When surfacing numbers to the user, attach the metric's `unit` (treat `null` as unitless). If you combine metrics with mismatched units in a single arithmetic expression, surface a warning rather than silently producing a meaningless number.
-
-**Cheap views over the listing.** For datasets with many metrics, the raw object is noisy. Two opt-in views are available:
-
-```bash
-# Group the listing by metric type
-scripts/metrics-info <deploy> <dataset> metrics --by-type
-
-# Filter to one or more types (repeatable; OR semantics; composes with --by-type)
-scripts/metrics-info <deploy> <dataset> metrics --type Histogram
-scripts/metrics-info <deploy> <dataset> metrics --type Gauge --type Histogram --by-type
-
-# Single-metric metadata block ({type, temporality, unit})
-scripts/metrics-info <deploy> <dataset> metrics <metric> info
-```
-
-All three are pure client-side reshapes of the same listing payload — no extra server calls.
-
----
+When surfacing numbers, attach the `unit` (treat `null` as unitless). If you combine metrics with mismatched units in arithmetic, warn rather than silently producing a meaningless number.
 
 ## Query Metrics
 
-Execute a metrics query against a dataset:
-
 ```bash
-scripts/metrics-query <deployment> '<mpl>' '<startTime>' '<endTime>'
+scripts/metrics-query <deploy> '<MPL>' <start> <end>
 ```
 
-**Examples:**
+| Parameter | Notes |
+|---|---|
+| `deploy` | Name from `~/.axiom.toml` (e.g. `prod`). |
+| `MPL` | Pipeline string. Dataset is parsed from the MPL itself. |
+| `start` / `end` | RFC3339 (`2025-01-01T00:00:00Z`) or relative (`now-1h`, `now`). |
+
+Examples:
+
 ```bash
-# Simple query
 scripts/metrics-query prod \
   '`my-dataset`:`http.server.duration` | align to 5m using avg' \
-  '2025-06-01T00:00:00Z' \
-  '2025-06-02T00:00:00Z'
+  now-1h now
 
-# Query with filtering (note backticks on dotted tag names)
 scripts/metrics-query prod \
-  '`my-dataset`:`http.server.duration` | where `service.name` == "frontend" and method == "GET" | align to 5m using avg | group by status_code using sum' \
-  'now-1d' \
-  'now'
+  '`my-dataset`:`http.server.duration`
+   | where `service.name` == "frontend" and method == "GET"
+   | align to 5m using avg
+   | group by status_code using sum' \
+  now-1d now
 ```
 
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `deployment` | Yes | Name from `~/.axiom.toml` (e.g., `prod`) |
-| `mpl` | Yes | Metrics query string. Dataset is extracted from the query itself. |
-| `startTime` | Yes | RFC3339 (e.g., `2025-01-01T00:00:00Z`) or relative expression (e.g., `now-1h`, `now-1d`) |
-| `endTime` | Yes | RFC3339 (e.g., `2025-01-02T00:00:00Z`) or relative expression (e.g., `now`) |
+### Parameters
 
-### Passing parameter values
-
-MPL queries can declare parameters (e.g. `param $svc: string;`). To run such a query, supply a value for each declared parameter alongside the query.
-
-**API contract.** `POST /v1/query/_mpl` accepts a `params` object on the JSON body, sibling to `apl` / `startTime` / `endTime`. Each entry's key is the parameter's variable name with the leading `$` stripped and a `param__` prefix added (`$foo` → `param__foo`); each entry's value is the MPL literal for that parameter. The server parses the literal according to the variable's declared type, so callers are responsible for formatting it as a valid MPL literal (per `metrics-spec`) and for any JSON-string escaping the literal requires.
-
-MPL parameters can be declared optional (see `metrics-spec` for the declaration syntax). Optional parameters may be omitted from `params`; required parameters must be supplied or the server returns HTTP 400 with a message like `The following params were declared but not provided: <name>`. Omit the `params` object entirely when the query declares no parameters or when every declared parameter is optional and you are not supplying any.
-
-Resulting request body shape:
-
-```json
-{
-  "apl": "param $svc: string; param $window: Duration; `otel-metrics`:`http.server.duration` | where `service.name` == $svc | align to $window using avg",
-  "startTime": "now-1h",
-  "endTime": "now",
-  "params": {
-    "param__svc": "\"frontend\"",
-    "param__window": "5m"
-  }
-}
-```
-
-Note that `param__svc` carries the MPL string literal `"frontend"` (the quotes are part of the literal), JSON-escaped as `"\"frontend\""`. `param__window` carries the duration literal `5m` verbatim.
-
-**Script invocation.** Pass each parameter with `-p name=value` (repeatable). The name is the bare variable name without the leading `$`; the script applies the `param__` prefix and forwards the value verbatim:
+MPL can declare parameters (`param $svc: string;`). Pass values with repeated `-p name=value`. The script applies the API's `param__` prefix; values are forwarded verbatim as MPL literals (string literals include their quotes).
 
 ```bash
 scripts/metrics-query \
   -p svc='"frontend"' \
   -p window='5m' \
   prod \
-  'param $svc: string; param $window: Duration; `otel-metrics`:`http.server.duration` | where `service.name` == $svc | align to $window using avg' \
+  'param $svc: string; param $window: Duration;
+   `otel-metrics`:`http.server.duration` | where `service.name` == $svc | align to $window using avg' \
   now-1h now
 ```
 
-For literal syntax per type (strings, durations, numbers, etc.), consult `metrics-spec`.
+Required parameters must be supplied; optional ones may be omitted. Resulting request body shape:
 
----
-
-## Discovery (Info Endpoints)
-
-Use `scripts/metrics-info` to explore what metrics, tags, and values exist in a dataset before writing queries. Time range defaults to the last 24 hours; override with `--start` and `--end`.
-
-### List metrics in a dataset
-
-```bash
-scripts/metrics-info <deployment> <dataset> metrics
+```json
+{
+  "apl": "param $svc: string; …",
+  "startTime": "now-1h",
+  "endTime": "now",
+  "params": { "param__svc": "\"frontend\"", "param__window": "5m" }
+}
 ```
 
-Returns a JSON object keyed by metric name; each value is `{type, temporality, unit}`. See [Choosing a query shape from metric metadata](#choosing-a-query-shape-from-metric-metadata) for how to use those fields.
+Literal syntax per type lives in `metrics-spec`.
 
-Opt-in views:
+## Discovery (`metrics-info`)
 
-```bash
-scripts/metrics-info <deployment> <dataset> metrics --by-type            # grouped by type
-scripts/metrics-info <deployment> <dataset> metrics --type Gauge         # filter (repeatable)
-scripts/metrics-info <deployment> <dataset> metrics --type Counter --type Histogram --by-type
-```
+Time range defaults to the last 24h; override with `--start` / `--end`.
 
-### Get a single metric's metadata
-
-```bash
-scripts/metrics-info <deployment> <dataset> metrics <metric> info
-```
-
-Returns just `{type, temporality, unit}` for the named metric. Exits non-zero if the metric is not present in the listing for the given time range.
-
-### List tags in a dataset
-
-```bash
-scripts/metrics-info <deployment> <dataset> tags
-```
-
-### List values for a specific tag
-
-```bash
-scripts/metrics-info <deployment> <dataset> tags <tag> values
-```
-
-### List tags for a specific metric
-
-```bash
-scripts/metrics-info <deployment> <dataset> metrics <metric> tags
-```
-
-### List tag values for a specific metric and tag
-
-```bash
-scripts/metrics-info <deployment> <dataset> metrics <metric> tags <tag> values
-```
-
-### Find metrics matching a tag value
-
-```bash
-scripts/metrics-info <deployment> <dataset> find-metrics "<search-value>"
-```
-
-### Custom time range
-
-All info commands accept `--start` and `--end` for custom time ranges:
-
-```bash
-scripts/metrics-info prod my-dataset metrics \
-  --start 2025-06-01T00:00:00Z \
-  --end 2025-06-02T00:00:00Z
-```
-
----
+| Command | Returns |
+|---|---|
+| `metrics-info <d> <ds> metrics` | All metrics, keyed by name, with `{type, temporality, unit}`. |
+| `metrics-info <d> <ds> metrics --by-type` | Same listing grouped by `type` (client-side reshape). |
+| `metrics-info <d> <ds> metrics --type Gauge --type Histogram` | Filtered listing (repeatable, OR semantics; composes with `--by-type`). |
+| `metrics-info <d> <ds> metrics <metric> info` | Single metric's `{type, temporality, unit}`. Non-zero exit if absent. |
+| `metrics-info <d> <ds> metrics <metric> describe` | Bundle: metadata + all tags + tag values in one call (replaces 1+1+N round trips). Flags: `--no-values` (tag names only), `--values-limit N` (cap per-tag values; default 50, 0 = unlimited). |
+| `metrics-info <d> <ds> metrics <metric> tags` | Tags carried by a specific metric. |
+| `metrics-info <d> <ds> metrics <metric> tags <tag> values` | Tag values for that metric. |
+| `metrics-info <d> <ds> metrics <metric> tags <tag> type` | Probe whether the tag is `int`/`float`/`string`/`bool`. Returns `{type, present_types}`; `mixed` if multiple types coexist, `absent` if not present. |
+| `metrics-info <d> <ds> tags` | All tags in the dataset. |
+| `metrics-info <d> <ds> tags <tag> values` | All values for a tag (across metrics). |
+| `metrics-info <d> <ds> find-metrics "<value>"` | Metrics that carry the given tag *value* (not metric name). |
 
 ## Error Handling
 
-HTTP errors return JSON with `message`, `code`, and optional `detail` fields:
+HTTP errors return JSON with `message`, `code`, and optional `detail`:
+
 ```json
-{"message": "description", "code": 400, "detail": {"errorType": 1, "message": "raw error"}}
+{"message": "...", "code": 400, "detail": {"errorType": 1, "message": "raw error"}}
 ```
 
-Common status codes:
-- 400 — Invalid query syntax or bad dataset name
-- 401 — Missing or invalid authentication
-- 403 — No permission to query/ingest this dataset
-- 404 — Dataset not found
-- 429 — Rate limited
-- 500 — Internal server error
+| Code | Cause |
+|---|---|
+| 400 | Invalid query syntax or bad dataset name |
+| 401 | Missing/invalid auth |
+| 403 | No permission |
+| 404 | Dataset not found |
+| 429 | Rate limited |
+| 500 | Internal error |
 
-On a **500 error**, re-run the failing script call with `curl -v` flags to capture response headers, then report the `traceparent` or `x-axiom-trace-id` header value to the user. This trace ID is essential for debugging the failure with the backend team.
-
----
+On 500, re-run with `curl -v` to capture the `traceparent` / `x-axiom-trace-id` header and report it — the trace ID is what the backend team needs to debug.
 
 ## Scripts
 
 | Script | Usage |
-|--------|-------|
-| `scripts/setup` | Check requirements and config |
-| `scripts/datasets <deploy> [--kind <kind>]` | List datasets (with edge deployment info) |
-| `scripts/metrics-spec <deploy> <dataset>` | Fetch metrics query specification |
-| `scripts/metrics-query <deploy> <mpl> <start> <end>` | Execute a metrics query |
-| `scripts/metrics-info <deploy> <dataset> ...` | Discover metrics, tags, and values |
-| `scripts/axiom-api <deploy> <method> <path> [body]` | Low-level API calls |
-| `scripts/resolve-url <deploy> <dataset>` | Resolve dataset to edge deployment URL |
+|---|---|
+| `scripts/setup` | Check requirements and config. |
+| `scripts/datasets <deploy> [--kind <kind>]` | List datasets with edge deployment. |
+| `scripts/metrics-spec <deploy> <dataset>` | Fetch the MPL query spec. |
+| `scripts/metrics-query <deploy> <mpl> <start> <end>` | Execute a query. |
+| `scripts/metrics-info <deploy> <dataset> ...` | Discover metrics, tags, values. |
+| `scripts/axiom-api <deploy> <method> <path> [body]` | Low-level API calls. |
+| `scripts/resolve-url <deploy> <dataset>` | Resolve to the edge deployment URL. |
 
-Run any script without arguments to see full usage.
+Run any script without arguments for full usage.

--- a/skills/query-metrics/SKILL.md
+++ b/skills/query-metrics/SKILL.md
@@ -72,7 +72,7 @@ Re-consult the spec when using an unfamiliar operator, when a query returns a sy
 
 1. **List datasets**: Run `scripts/datasets <deployment>` to see available datasets and their edge deployments
 2. **Fetch the spec**: Run `scripts/metrics-spec <deployment> <dataset>` — **this step is mandatory before writing any query**
-3. **Discover metrics**: List available metrics via `scripts/metrics-info <deployment> <dataset> metrics`
+3. **Discover and classify metrics**: List available metrics via `scripts/metrics-info <deployment> <dataset> metrics`. The response carries each metric's `type`, `temporality`, and `unit` — read these before composing a query (see [Choosing a query shape from metric metadata](#choosing-a-query-shape-from-metric-metadata) below).
 4. **Explore tags**: List tags and tag values to understand filtering options. If metrics listing fails, use tags and tag values to identify relevant entities, then use those to list metrics for specific tags.
 5. **Write and execute query**: Compose a metrics query and run it via `scripts/metrics-query`
 6. **Iterate**: Refine filters, aggregations, and groupings based on results
@@ -81,7 +81,46 @@ If the user provides a specific service, host, or entity name to search for, use
 ```bash
 scripts/metrics-info <deployment> <dataset> find-metrics "frontend"
 ```
-Do NOT use `find-metrics` as a general discovery step — it requires a known search value.
+Do NOT use `find-metrics` as a general discovery step — it requires a known search value. After `find-metrics` returns candidates, fetch each one's metadata with `metrics-info … metrics <metric> info` before writing a query against it.
+
+---
+
+## Choosing a query shape from metric metadata
+
+The `metrics` listing returns a v2 payload where each metric carries three fields that should drive how you write the MPL query. **Always read this metadata before composing a query — never assume a metric is a simple scalar.**
+
+| Field | Values | What it tells you |
+|-------|--------|-------------------|
+| `type` | `Gauge`, `CounterMonotonic`, `CounterNonMonotonic`, `Histogram` | The kind of instrument; determines required pre-aggregation operators |
+| `temporality` | `Cumulative`, `Delta`, or `null` | Whether counter values are running totals or per-interval deltas. `null` is normal for Gauges. |
+| `unit` | UCUM-style string (`Cel`, `kW.h`, `s`, `%`, `[ppm]`, …) or `null` | Display unit; preserve when reporting results to the user |
+
+**Rules of thumb (consult `metrics-spec` for the exact operator names — they may evolve):**
+
+- **Gauge** — instantaneous value. Align directly with `avg`/`min`/`max`/`sum`. Do **not** apply a rate operator; you'd be averaging meaningless deltas of an instantaneous value.
+- **CounterMonotonic + Cumulative** — running total that only goes up (resets aside). The raw values are almost never what the user wants. Convert to a per-second rate first, **then** align/aggregate. Look up the rate operator in the spec's standard library.
+- **CounterMonotonic + Delta** — already per-interval; can be summed/aligned without a rate step.
+- **CounterNonMonotonic** — can go up or down (e.g. queue depth, balance). Intent is ambiguous: rate, delta, or current value all make sense for different questions. **Ask the user what they want to see** before picking one.
+- **Histogram** — not a scalar. Direct `align using avg` will not give you what you expect. Consult the histogram section of `metrics-spec` for quantile/bucket operators.
+- **`temporality: null`** means "not applicable for this instrument type" (the norm for Gauges), not "missing data".
+
+**Reporting results.** When surfacing numbers to the user, attach the metric's `unit` (treat `null` as unitless). If you combine metrics with mismatched units in a single arithmetic expression, surface a warning rather than silently producing a meaningless number.
+
+**Cheap views over the listing.** For datasets with many metrics, the raw object is noisy. Two opt-in views are available:
+
+```bash
+# Group the listing by metric type
+scripts/metrics-info <deploy> <dataset> metrics --by-type
+
+# Filter to one or more types (repeatable; OR semantics; composes with --by-type)
+scripts/metrics-info <deploy> <dataset> metrics --type Histogram
+scripts/metrics-info <deploy> <dataset> metrics --type Gauge --type Histogram --by-type
+
+# Single-metric metadata block ({type, temporality, unit})
+scripts/metrics-info <deploy> <dataset> metrics <metric> info
+```
+
+All three are pure client-side reshapes of the same listing payload — no extra server calls.
 
 ---
 
@@ -163,6 +202,24 @@ Use `scripts/metrics-info` to explore what metrics, tags, and values exist in a 
 ```bash
 scripts/metrics-info <deployment> <dataset> metrics
 ```
+
+Returns a JSON object keyed by metric name; each value is `{type, temporality, unit}`. See [Choosing a query shape from metric metadata](#choosing-a-query-shape-from-metric-metadata) for how to use those fields.
+
+Opt-in views:
+
+```bash
+scripts/metrics-info <deployment> <dataset> metrics --by-type            # grouped by type
+scripts/metrics-info <deployment> <dataset> metrics --type Gauge         # filter (repeatable)
+scripts/metrics-info <deployment> <dataset> metrics --type Counter --type Histogram --by-type
+```
+
+### Get a single metric's metadata
+
+```bash
+scripts/metrics-info <deployment> <dataset> metrics <metric> info
+```
+
+Returns just `{type, temporality, unit}` for the named metric. Exits non-zero if the metric is not present in the listing for the given time range.
 
 ### List tags in a dataset
 

--- a/skills/query-metrics/SKILL.md
+++ b/skills/query-metrics/SKILL.md
@@ -115,6 +115,43 @@ scripts/metrics-query prod \
 | `startTime` | Yes | RFC3339 (e.g., `2025-01-01T00:00:00Z`) or relative expression (e.g., `now-1h`, `now-1d`) |
 | `endTime` | Yes | RFC3339 (e.g., `2025-01-02T00:00:00Z`) or relative expression (e.g., `now`) |
 
+### Passing parameter values
+
+MPL queries can declare parameters (e.g. `param $svc: string;`). To run such a query, supply a value for each declared parameter alongside the query.
+
+**API contract.** `POST /v1/query/_mpl` accepts a `params` object on the JSON body, sibling to `apl` / `startTime` / `endTime`. Each entry's key is the parameter's variable name with the leading `$` stripped and a `param__` prefix added (`$foo` → `param__foo`); each entry's value is the MPL literal for that parameter. The server parses the literal according to the variable's declared type, so callers are responsible for formatting it as a valid MPL literal (per `metrics-spec`) and for any JSON-string escaping the literal requires.
+
+MPL parameters can be declared optional (see `metrics-spec` for the declaration syntax). Optional parameters may be omitted from `params`; required parameters must be supplied or the server returns HTTP 400 with a message like `The following params were declared but not provided: <name>`. Omit the `params` object entirely when the query declares no parameters or when every declared parameter is optional and you are not supplying any.
+
+Resulting request body shape:
+
+```json
+{
+  "apl": "param $svc: string; param $window: Duration; `otel-metrics`:`http.server.duration` | where `service.name` == $svc | align to $window using avg",
+  "startTime": "now-1h",
+  "endTime": "now",
+  "params": {
+    "param__svc": "\"frontend\"",
+    "param__window": "5m"
+  }
+}
+```
+
+Note that `param__svc` carries the MPL string literal `"frontend"` (the quotes are part of the literal), JSON-escaped as `"\"frontend\""`. `param__window` carries the duration literal `5m` verbatim.
+
+**Script invocation.** Pass each parameter with `-p name=value` (repeatable). The name is the bare variable name without the leading `$`; the script applies the `param__` prefix and forwards the value verbatim:
+
+```bash
+scripts/metrics-query \
+  -p svc='"frontend"' \
+  -p window='5m' \
+  prod \
+  'param $svc: string; param $window: Duration; `otel-metrics`:`http.server.duration` | where `service.name` == $svc | align to $window using avg' \
+  now-1h now
+```
+
+For literal syntax per type (strings, durations, numbers, etc.), consult `metrics-spec`.
+
 ---
 
 ## Discovery (Info Endpoints)

--- a/skills/query-metrics/scripts/metrics-info
+++ b/skills/query-metrics/scripts/metrics-info
@@ -4,10 +4,12 @@
 # Usage:
 #   metrics-info <deployment> <dataset> metrics [--by-type] [--type T]... [--start T --end T]
 #   metrics-info <deployment> <dataset> metrics <metric> info [--start T --end T]
-#   metrics-info <deployment> <dataset> tags    [--start T --end T]
-#   metrics-info <deployment> <dataset> tags <tag> values [--start T --end T]
+#   metrics-info <deployment> <dataset> metrics <metric> describe [--no-values] [--values-limit N] [--start T --end T]
 #   metrics-info <deployment> <dataset> metrics <metric> tags [--start T --end T]
 #   metrics-info <deployment> <dataset> metrics <metric> tags <tag> values [--start T --end T]
+#   metrics-info <deployment> <dataset> metrics <metric> tags <tag> type [--start T --end T]
+#   metrics-info <deployment> <dataset> tags    [--start T --end T]
+#   metrics-info <deployment> <dataset> tags <tag> values [--start T --end T]
 #   metrics-info <deployment> <dataset> find-metrics <search-value> [--start T --end T]
 #
 # Metric metadata. The `metrics` listing returns a v2 payload where each entry
@@ -23,14 +25,27 @@
 #                       Repeatable; multiple --type flags act as OR.
 #                       Composes with --by-type.
 #
-# The `metrics <metric> info` subcommand extracts a single metric's metadata
-# block ({type, temporality, unit}) from the bulk listing. Exits non-zero if
-# the metric is not present in the listing for the given time range.
+# `metrics <metric> info` extracts a single metric's metadata block
+# ({type, temporality, unit}). Non-zero exit if the metric is absent.
 #
-# find-metrics searches TAG VALUES, not metric names. It returns metrics that have
-# a tag containing the given value. Use it when you know a specific entity name
-# (service, host, device) to find which metrics are associated with it.
-# To list metric names, use the "metrics" subcommand instead.
+# `metrics <metric> describe` bundles metadata + tags + tag values for one
+# metric in a single call (replaces the typical 1+1+N round trips).
+#   --no-values         Return tag names only, not values (1+1 calls).
+#   --values-limit N    Cap each tag's value list at N entries (default 50;
+#                       0 = no limit). Applied client-side after fetch.
+#
+# `metrics <metric> tags <tag> type` probes whether a tag is int/float/string/
+# bool-typed by running `metrics-query` with `filter <tag> is <T>` for each.
+# Returns:
+#   {"type": "int", "present_types": ["int"]}
+#   {"type": "mixed", "present_types": ["int","string"]}
+#   {"type": "absent", "present_types": []}
+# (mixed = the tag carries different types across rows; use the defensive
+# `(tag is int and tag == 200) or (tag is string and tag == "200")` form.)
+#
+# find-metrics searches TAG VALUES, not metric names. Use it when you know a
+# specific entity name (service, host, device) to find which metrics carry it.
+# To list metric names, use the `metrics` subcommand instead.
 #
 # --start and --end default to the last 24 hours if omitted.
 # For sparse metrics (sensors, batch jobs), try --start with a wider range (e.g. 7 days).
@@ -41,6 +56,9 @@
 #   metrics-info prod my-dataset metrics --type Histogram               # Only histograms
 #   metrics-info prod my-dataset metrics --type Gauge --type Histogram --by-type
 #   metrics-info prod my-dataset metrics http.server.duration info      # Single metric meta
+#   metrics-info prod my-dataset metrics http.server.duration describe  # Bundle: meta + tags + values
+#   metrics-info prod my-dataset metrics http.server.duration describe --no-values
+#   metrics-info prod my-dataset metrics http.server.duration tags code type
 #   metrics-info prod my-dataset tags service.name values               # List values for a tag
 #   metrics-info prod my-dataset find-metrics "frontend"                # Find metrics with tag value "frontend"
 #   metrics-info prod my-dataset metrics http.server.duration tags --start 2025-06-01T00:00:00Z --end 2025-06-02T00:00:00Z
@@ -53,17 +71,21 @@ show_usage() {
     echo "Usage:" >&2
     echo "  metrics-info <deploy> <dataset> metrics [--by-type] [--type T]..." >&2
     echo "  metrics-info <deploy> <dataset> metrics <metric> info" >&2
+    echo "  metrics-info <deploy> <dataset> metrics <metric> describe [--no-values] [--values-limit N]" >&2
     echo "  metrics-info <deploy> <dataset> metrics <metric> tags" >&2
     echo "  metrics-info <deploy> <dataset> metrics <metric> tags <tag> values" >&2
+    echo "  metrics-info <deploy> <dataset> metrics <metric> tags <tag> type" >&2
     echo "  metrics-info <deploy> <dataset> tags" >&2
     echo "  metrics-info <deploy> <dataset> tags <tag> values" >&2
     echo "  metrics-info <deploy> <dataset> find-metrics <search-value>  (searches tag values, not metric names)" >&2
     echo "" >&2
     echo "Options:" >&2
-    echo "  --start T    Start time (RFC3339). Default: 24h ago" >&2
-    echo "  --end T      End time (RFC3339). Default: now" >&2
-    echo "  --by-type    (metrics listing) Group entries by metric type" >&2
-    echo "  --type T     (metrics listing) Filter to type T (Gauge|CounterMonotonic|CounterNonMonotonic|Histogram). Repeatable." >&2
+    echo "  --start T          Start time (RFC3339). Default: 24h ago" >&2
+    echo "  --end T            End time (RFC3339). Default: now" >&2
+    echo "  --by-type          (metrics listing) Group entries by metric type" >&2
+    echo "  --type T           (metrics listing) Filter to type T. Repeatable." >&2
+    echo "  --no-values        (describe) Return tag names only" >&2
+    echo "  --values-limit N   (describe) Cap each tag's value list at N (default 50; 0 = unlimited)" >&2
     exit 1
 }
 
@@ -76,19 +98,23 @@ fi
 
 shift 2
 
-# Collect positional args and parse --start/--end and listing-view flags
+# Collect positional args and parse --start/--end, listing-view, describe flags.
 POSITIONAL=()
 START=""
 END=""
 BY_TYPE=0
 TYPE_FILTERS=()
+NO_VALUES=0
+VALUES_LIMIT=50
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --start)    START="$2"; shift 2 ;;
-        --end)      END="$2"; shift 2 ;;
-        --by-type)  BY_TYPE=1; shift ;;
-        --type)     TYPE_FILTERS+=("$2"); shift 2 ;;
-        *)          POSITIONAL+=("$1"); shift ;;
+        --start)         START="$2"; shift 2 ;;
+        --end)           END="$2"; shift 2 ;;
+        --by-type)       BY_TYPE=1; shift ;;
+        --type)          TYPE_FILTERS+=("$2"); shift 2 ;;
+        --no-values)     NO_VALUES=1; shift ;;
+        --values-limit)  VALUES_LIMIT="$2"; shift 2 ;;
+        *)               POSITIONAL+=("$1"); shift ;;
     esac
 done
 
@@ -154,6 +180,30 @@ case "${POSITIONAL[0]}" in
             RAW=$(fetch_metrics_listing)
             # -e exits non-zero when the value is null/false; we want non-zero on missing.
             printf '%s' "$RAW" | jq -e --arg m "$METRIC" '.[$m] // error("metric not found in listing for the given time range: " + $m)'
+        elif [[ ${#POSITIONAL[@]} -eq 3 && "${POSITIONAL[2]}" == "describe" ]]; then
+            # Bundle metadata + tags + tag values into a single output. Replaces
+            # the typical 1+1+N round trips an agent would make to characterise
+            # an unfamiliar metric.
+            METRIC="${POSITIONAL[1]}"
+            RAW=$(fetch_metrics_listing)
+            META=$(printf '%s' "$RAW" | jq -e --arg m "$METRIC" '.[$m] // error("metric not found in listing for the given time range: " + $m)')
+            TAGS_JSON=$("$SCRIPT_DIR/axiom-api" "$DEPLOYMENT" GET "${BASE}/metrics/${METRIC}/tags?${TIME_PARAMS}")
+            if [[ "$NO_VALUES" -eq 1 ]]; then
+                # tags as flat array of names
+                jq -n --argjson m "$META" --argjson tags "$TAGS_JSON" '$m + {tags: $tags}'
+            else
+                # tags as object: { tag_name: [values…] }
+                VALUES_OBJ='{}'
+                while IFS= read -r tag; do
+                    [[ -z "$tag" ]] && continue
+                    VALUES=$("$SCRIPT_DIR/axiom-api" "$DEPLOYMENT" GET "${BASE}/metrics/${METRIC}/tags/${tag}/values?${TIME_PARAMS}")
+                    if [[ "$VALUES_LIMIT" -gt 0 ]]; then
+                        VALUES=$(printf '%s' "$VALUES" | jq --argjson n "$VALUES_LIMIT" '.[:$n]')
+                    fi
+                    VALUES_OBJ=$(jq -n --argjson o "$VALUES_OBJ" --arg t "$tag" --argjson v "$VALUES" '$o + {($t): $v}')
+                done < <(printf '%s' "$TAGS_JSON" | jq -r '.[]?')
+                jq -n --argjson m "$META" --argjson tags "$VALUES_OBJ" '$m + {tags: $tags}'
+            fi
         elif [[ ${#POSITIONAL[@]} -eq 3 && "${POSITIONAL[2]}" == "tags" ]]; then
             # List tags for a metric
             METRIC="${POSITIONAL[1]}"
@@ -163,6 +213,35 @@ case "${POSITIONAL[0]}" in
             METRIC="${POSITIONAL[1]}"
             TAG="${POSITIONAL[3]}"
             "$SCRIPT_DIR/axiom-api" "$DEPLOYMENT" GET "${BASE}/metrics/${METRIC}/tags/${TAG}/values?${TIME_PARAMS}"
+        elif [[ ${#POSITIONAL[@]} -eq 5 && "${POSITIONAL[2]}" == "tags" && "${POSITIONAL[4]}" == "type" ]]; then
+            # Probe the typing of a metric+tag by running `metrics-query` with
+            # `filter <tag> is <T>` for each candidate type. The type(s) that
+            # return non-empty `series` are present in the dataset for that
+            # metric+tag in the time window.
+            METRIC="${POSITIONAL[1]}"
+            TAG="${POSITIONAL[3]}"
+            PRESENT_JSON='[]'
+            for t in int float string bool; do
+                # Backtick-escape dataset / metric / tag names. The probe pipeline:
+                #   `<dataset>`:`<metric>` | filter `<tag>` is <T> | align to 5m using sum
+                # If <tag> is <T> matches no rows, the response has empty `series`.
+                PROBE_QUERY='`'"$DATASET"'`:`'"$METRIC"'` | filter `'"$TAG"'` is '"$t"' | align to 5m using sum'
+                RESPONSE=$("$SCRIPT_DIR/metrics-query" "$DEPLOYMENT" "$PROBE_QUERY" "$START" "$END" 2>/dev/null || echo '{}')
+                COUNT=$(printf '%s' "$RESPONSE" | jq -r '(.series // []) | length' 2>/dev/null || echo 0)
+                if [[ "$COUNT" -gt 0 ]]; then
+                    PRESENT_JSON=$(printf '%s' "$PRESENT_JSON" | jq --arg t "$t" '. + [$t]')
+                fi
+            done
+            jq -n --argjson present "$PRESENT_JSON" '
+                {
+                    type: (
+                        if   ($present | length) == 0 then "absent"
+                        elif ($present | length) == 1 then $present[0]
+                        else                                "mixed"
+                        end
+                    ),
+                    present_types: $present
+                }'
         else
             show_usage
         fi

--- a/skills/query-metrics/scripts/metrics-info
+++ b/skills/query-metrics/scripts/metrics-info
@@ -2,12 +2,30 @@
 # metrics-info: Discover metrics, tags, and tag values in a dataset
 #
 # Usage:
-#   metrics-info <deployment> <dataset> metrics [--start T --end T]
+#   metrics-info <deployment> <dataset> metrics [--by-type] [--type T]... [--start T --end T]
+#   metrics-info <deployment> <dataset> metrics <metric> info [--start T --end T]
 #   metrics-info <deployment> <dataset> tags    [--start T --end T]
 #   metrics-info <deployment> <dataset> tags <tag> values [--start T --end T]
 #   metrics-info <deployment> <dataset> metrics <metric> tags [--start T --end T]
 #   metrics-info <deployment> <dataset> metrics <metric> tags <tag> values [--start T --end T]
 #   metrics-info <deployment> <dataset> find-metrics <search-value> [--start T --end T]
+#
+# Metric metadata. The `metrics` listing returns a v2 payload where each entry
+# carries `type` (Gauge | CounterMonotonic | CounterNonMonotonic | Histogram),
+# `temporality` (Cumulative | Delta | null), and `unit` (UCUM string or null).
+# Use this metadata to choose the right MPL query shape (consult metrics-spec
+# for the exact operator names per type).
+#
+#   --by-type           Group the listing by `type` instead of returning a flat
+#                       name->meta object. Pure client-side reshape; no extra
+#                       server call.
+#   --type T            Filter the listing to entries whose `type` equals T.
+#                       Repeatable; multiple --type flags act as OR.
+#                       Composes with --by-type.
+#
+# The `metrics <metric> info` subcommand extracts a single metric's metadata
+# block ({type, temporality, unit}) from the bulk listing. Exits non-zero if
+# the metric is not present in the listing for the given time range.
 #
 # find-metrics searches TAG VALUES, not metric names. It returns metrics that have
 # a tag containing the given value. Use it when you know a specific entity name
@@ -18,9 +36,13 @@
 # For sparse metrics (sensors, batch jobs), try --start with a wider range (e.g. 7 days).
 #
 # Examples:
-#   metrics-info prod my-dataset metrics                    # List all metric names
-#   metrics-info prod my-dataset tags service.name values   # List values for a tag
-#   metrics-info prod my-dataset find-metrics "frontend"    # Find metrics with tag value "frontend"
+#   metrics-info prod my-dataset metrics                                # Raw listing
+#   metrics-info prod my-dataset metrics --by-type                      # Grouped by type
+#   metrics-info prod my-dataset metrics --type Histogram               # Only histograms
+#   metrics-info prod my-dataset metrics --type Gauge --type Histogram --by-type
+#   metrics-info prod my-dataset metrics http.server.duration info      # Single metric meta
+#   metrics-info prod my-dataset tags service.name values               # List values for a tag
+#   metrics-info prod my-dataset find-metrics "frontend"                # Find metrics with tag value "frontend"
 #   metrics-info prod my-dataset metrics http.server.duration tags --start 2025-06-01T00:00:00Z --end 2025-06-02T00:00:00Z
 
 set -euo pipefail
@@ -29,16 +51,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 show_usage() {
     echo "Usage:" >&2
-    echo "  metrics-info <deploy> <dataset> metrics" >&2
-    echo "  metrics-info <deploy> <dataset> tags" >&2
-    echo "  metrics-info <deploy> <dataset> tags <tag> values" >&2
+    echo "  metrics-info <deploy> <dataset> metrics [--by-type] [--type T]..." >&2
+    echo "  metrics-info <deploy> <dataset> metrics <metric> info" >&2
     echo "  metrics-info <deploy> <dataset> metrics <metric> tags" >&2
     echo "  metrics-info <deploy> <dataset> metrics <metric> tags <tag> values" >&2
+    echo "  metrics-info <deploy> <dataset> tags" >&2
+    echo "  metrics-info <deploy> <dataset> tags <tag> values" >&2
     echo "  metrics-info <deploy> <dataset> find-metrics <search-value>  (searches tag values, not metric names)" >&2
     echo "" >&2
     echo "Options:" >&2
-    echo "  --start T   Start time (RFC3339). Default: 24h ago" >&2
-    echo "  --end T     End time (RFC3339). Default: now" >&2
+    echo "  --start T    Start time (RFC3339). Default: 24h ago" >&2
+    echo "  --end T      End time (RFC3339). Default: now" >&2
+    echo "  --by-type    (metrics listing) Group entries by metric type" >&2
+    echo "  --type T     (metrics listing) Filter to type T (Gauge|CounterMonotonic|CounterNonMonotonic|Histogram). Repeatable." >&2
     exit 1
 }
 
@@ -51,15 +76,19 @@ fi
 
 shift 2
 
-# Collect positional args and parse --start/--end
+# Collect positional args and parse --start/--end and listing-view flags
 POSITIONAL=()
 START=""
 END=""
+BY_TYPE=0
+TYPE_FILTERS=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --start) START="$2"; shift 2 ;;
-        --end)   END="$2"; shift 2 ;;
-        *)       POSITIONAL+=("$1"); shift ;;
+        --start)    START="$2"; shift 2 ;;
+        --end)      END="$2"; shift 2 ;;
+        --by-type)  BY_TYPE=1; shift ;;
+        --type)     TYPE_FILTERS+=("$2"); shift 2 ;;
+        *)          POSITIONAL+=("$1"); shift ;;
     esac
 done
 
@@ -88,11 +117,43 @@ if [[ ${#POSITIONAL[@]} -eq 0 ]]; then
     show_usage
 fi
 
+# Fetch the bulk metrics listing (v2 payload with type/temporality/unit per metric).
+# Used directly by `metrics` and indirectly by `metrics <metric> info`.
+fetch_metrics_listing() {
+    AXIOM_ACCEPT="application/vnd.metrics-info.v2+json" "$SCRIPT_DIR/axiom-api" "$DEPLOYMENT" GET "${BASE}/metrics?${TIME_PARAMS}"
+}
+
 case "${POSITIONAL[0]}" in
     metrics)
         if [[ ${#POSITIONAL[@]} -eq 1 ]]; then
-            # List metrics
-            AXIOM_ACCEPT="application/vnd.metrics-info.v2+json" "$SCRIPT_DIR/axiom-api" "$DEPLOYMENT" GET "${BASE}/metrics?${TIME_PARAMS}"
+            # List metrics. Default behaviour returns the raw v2 payload byte-for-byte;
+            # --type / --by-type apply pure client-side reshapes via jq.
+            if [[ $BY_TYPE -eq 0 && ${#TYPE_FILTERS[@]} -eq 0 ]]; then
+                fetch_metrics_listing
+            else
+                RAW=$(fetch_metrics_listing)
+                JQ_FILTER='.'
+                if [[ ${#TYPE_FILTERS[@]} -gt 0 ]]; then
+                    # Build a JSON array of allowed types and filter entries.
+                    TYPES_JSON=$(printf '%s\n' "${TYPE_FILTERS[@]}" | jq -R . | jq -s .)
+                    JQ_FILTER='to_entries | map(select(.value.type as $vt | ($types | index($vt)))) | from_entries'
+                    if [[ $BY_TYPE -eq 1 ]]; then
+                        JQ_FILTER="$JQ_FILTER"' | to_entries | group_by(.value.type) | map({(.[0].value.type): (map({(.key): {temporality: .value.temporality, unit: .value.unit}}) | add)}) | add // {}'
+                    fi
+                    printf '%s' "$RAW" | jq --argjson types "$TYPES_JSON" "$JQ_FILTER"
+                else
+                    # --by-type only
+                    JQ_FILTER='to_entries | group_by(.value.type) | map({(.[0].value.type): (map({(.key): {temporality: .value.temporality, unit: .value.unit}}) | add)}) | add // {}'
+                    printf '%s' "$RAW" | jq "$JQ_FILTER"
+                fi
+            fi
+        elif [[ ${#POSITIONAL[@]} -eq 3 && "${POSITIONAL[2]}" == "info" ]]; then
+            # Single-metric metadata: {type, temporality, unit}. Derived client-side
+            # from the bulk listing because there is no per-metric metadata endpoint.
+            METRIC="${POSITIONAL[1]}"
+            RAW=$(fetch_metrics_listing)
+            # -e exits non-zero when the value is null/false; we want non-zero on missing.
+            printf '%s' "$RAW" | jq -e --arg m "$METRIC" '.[$m] // error("metric not found in listing for the given time range: " + $m)'
         elif [[ ${#POSITIONAL[@]} -eq 3 && "${POSITIONAL[2]}" == "tags" ]]; then
             # List tags for a metric
             METRIC="${POSITIONAL[1]}"

--- a/skills/query-metrics/scripts/metrics-query
+++ b/skills/query-metrics/scripts/metrics-query
@@ -1,33 +1,111 @@
 #!/usr/bin/env bash
 # metrics-query: Execute a metrics query against Axiom MetricsDB
 #
-# Usage: metrics-query <deployment> <mpl> <startTime> <endTime>
+# Usage: metrics-query [-p name=value]... <deployment> <mpl> <startTime> <endTime>
 #
 # Times: RFC3339 (e.g. 2025-01-01T00:00:00Z) or relative (e.g. now-1h, now-1d).
+#
+# Parameter values (-p / --param name=value, repeatable):
+#   For each MPL parameter declared in the query (e.g. `param $svc: string;`),
+#   pass the variable name without the leading `$` and an MPL literal as the
+#   value. The script applies the `param__` prefix to the key and forwards the
+#   value verbatim under the request body's `params` object — i.e. `-p svc=...`
+#   becomes `params.param__svc`. Callers are responsible for formatting the
+#   value as a valid MPL literal (per the metrics spec) and for any quoting
+#   the literal requires; the server parses it according to the variable's
+#   declared type. Parameters declared optional in the MPL (see metrics-spec)
+#   may be omitted; required parameters must be supplied or the server returns
+#   HTTP 400.
 #
 # Examples:
 #   metrics-query prod '`otel-metrics`:`http.server.duration` | align to 5m using avg | group by `endpoint` using sum' \
 #     '2025-06-01T00:00:00Z' '2025-06-02T00:00:00Z'
 #   metrics-query prod '`otel-metrics`:`http.server.duration` | align to 5m using avg' now-1h now
+#   # With parameters $svc: string and $window: Duration:
+#   metrics-query -p svc='"frontend"' -p window='5m' prod \
+#     'param $svc: string; param $window: Duration; `otel-metrics`:`http.server.duration` | where `service.name` == $svc | align to $window using avg' \
+#     now-1h now
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-DEPLOYMENT="${1:-}"
-MPL="${2:-}"
-START_TIME="${3:-}"
-END_TIME="${4:-}"
+PARAMS=()
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -p|--param)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: $1 requires an argument of the form name=value" >&2
+                exit 1
+            fi
+            PARAMS+=("$2")
+            shift 2
+            ;;
+        --param=*)
+            PARAMS+=("${1#--param=}")
+            shift
+            ;;
+        --)
+            shift
+            while [[ $# -gt 0 ]]; do POSITIONAL+=("$1"); shift; done
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+
+DEPLOYMENT="${POSITIONAL[0]:-}"
+MPL="${POSITIONAL[1]:-}"
+START_TIME="${POSITIONAL[2]:-}"
+END_TIME="${POSITIONAL[3]:-}"
 
 if [[ -z "$DEPLOYMENT" || -z "$MPL" || -z "$START_TIME" || -z "$END_TIME" ]]; then
-    echo "Usage: metrics-query <deployment> <mpl> <startTime> <endTime>" >&2
+    echo "Usage: metrics-query [-p name=value]... <deployment> <mpl> <startTime> <endTime>" >&2
     echo "" >&2
     echo "Times: RFC3339 (e.g. 2025-01-01T00:00:00Z) or relative (e.g. now-1h, now-1d)." >&2
+    echo "" >&2
+    echo "-p / --param name=value (repeatable): supply an MPL parameter value." >&2
+    echo "  name  - variable name without the leading \$ (e.g. 'svc' for \$svc)." >&2
+    echo "  value - MPL literal, forwarded verbatim under params.param__<name>." >&2
     exit 1
 fi
 
+# Validate and split params into parallel name/value arrays.
+PARAM_NAMES=()
+PARAM_VALUES=()
+if [[ ${#PARAMS[@]} -gt 0 ]]; then
+    for entry in "${PARAMS[@]}"; do
+        if [[ "$entry" != *"="* ]]; then
+            echo "Error: -p expects name=value, got: $entry" >&2
+            exit 1
+        fi
+        name="${entry%%=*}"
+        value="${entry#*=}"
+        if [[ -z "$name" ]]; then
+            echo "Error: -p name is empty in: $entry" >&2
+            exit 1
+        fi
+        if [[ "${name:0:1}" == "\$" ]]; then
+            echo "Error: -p name must not include the leading \$ (got: $name); pass the bare variable name" >&2
+            exit 1
+        fi
+        PARAM_NAMES+=("$name")
+        PARAM_VALUES+=("$value")
+    done
+fi
+
 # Extract dataset name from MPL: `dataset`:`metric` ... or dataset:`metric` ...
-DATASET=$(echo "$MPL" | sed 's/`//g' | cut -d: -f1 | tr -d '[:space:]')
+# Strip leading `param <name>: <type>;` declarations first so their `:` doesn't
+# get mistaken for the dataset:metric separator.
+PIPELINE="$MPL"
+while [[ "$PIPELINE" =~ ^[[:space:]]*[Pp]aram[[:space:]] ]]; do
+    if [[ "$PIPELINE" != *";"* ]]; then break; fi
+    PIPELINE="${PIPELINE#*;}"
+done
+DATASET=$(echo "$PIPELINE" | sed 's/`//g' | cut -d: -f1 | tr -d '[:space:]')
 
 QUERY_EDGE_DEPLOYMENT=""
 if [[ -n "$DATASET" ]]; then
@@ -46,11 +124,21 @@ JQ_ARGS=(
     --arg startT "$START_TIME"
     --arg endT "$END_TIME"
 )
-JQ_EXPR='{"apl": $apl, "startTime": $startT, "endTime": $endT}'
+JQ_EXPR='{apl: $apl, startTime: $startT, endTime: $endT}'
 
 if [[ -n "$QUERY_EDGE_DEPLOYMENT" ]]; then
     JQ_ARGS+=(--arg edgeDeployment "$QUERY_EDGE_DEPLOYMENT")
-    JQ_EXPR='{"apl": $apl, "startTime": $startT, "endTime": $endT, "queryEdgeDeployment": $edgeDeployment}'
+    JQ_EXPR="$JQ_EXPR + {queryEdgeDeployment: \$edgeDeployment}"
+fi
+
+if [[ ${#PARAM_NAMES[@]} -gt 0 ]]; then
+    PARAMS_EXPR=""
+    for i in "${!PARAM_NAMES[@]}"; do
+        JQ_ARGS+=(--arg "pn$i" "${PARAM_NAMES[$i]}" --arg "pv$i" "${PARAM_VALUES[$i]}")
+        if [[ -n "$PARAMS_EXPR" ]]; then PARAMS_EXPR+=" + "; fi
+        PARAMS_EXPR+="{(\"param__\" + \$pn$i): \$pv$i}"
+    done
+    JQ_EXPR="$JQ_EXPR + {params: ($PARAMS_EXPR)}"
 fi
 
 BODY=$(jq -n "${JQ_ARGS[@]}" "$JQ_EXPR")

--- a/skills/query-metrics/scripts/resolve-url
+++ b/skills/query-metrics/scripts/resolve-url
@@ -10,6 +10,13 @@
 #   cloud.us-east-1.aws    → https://us-east-1.aws.edge.axiom.co
 #   cloud.eu-central-1.aws → https://eu-central-1.aws.edge.axiom.co
 #   (null/empty)           → falls back to deployment URL from config
+#
+# Environment overrides:
+#   AXIOM_URL_OVERRIDE     → if set, returned verbatim and no API/cache
+#                            lookup is performed. Mirrors axiom-api's own
+#                            AXIOM_URL_OVERRIDE handling so callers can
+#                            point both scripts at a non-default edge with
+#                            a single env var.
 
 set -euo pipefail
 
@@ -21,6 +28,14 @@ DATASET="${2:-}"
 if [[ -z "$DEPLOYMENT" || -z "$DATASET" ]]; then
     echo "Usage: resolve-url <deployment> <dataset>" >&2
     exit 1
+fi
+
+# Honour an explicit override before touching the cache or the API.
+# Skipping the cache write keeps session-scoped overrides from leaking
+# into later invocations that don't set the env var.
+if [[ -n "${AXIOM_URL_OVERRIDE:-}" ]]; then
+    echo "$AXIOM_URL_OVERRIDE"
+    exit 0
 fi
 
 CONFIG_FILE="$HOME/.axiom.toml"
@@ -51,7 +66,7 @@ extract_value() {
 
 FALLBACK_URL=$(extract_value "url")
 
-EDGE_DEPLOYMENT=$("$SCRIPT_DIR/axiom-api" "$DEPLOYMENT" GET /v1/datasets \
+EDGE_DEPLOYMENT=$("$SCRIPT_DIR/axiom-api" "$DEPLOYMENT" GET /v2/datasets \
     | jq -r --arg name "$DATASET" '.[] | select(.name == $name) | .edgeDeployment // empty')
 
 RESOLVED_URL=""


### PR DESCRIPTION
## Summary

Originally a focused docs change for MPL parameter values in `scripts/metrics-query`. While exercising the change against real Kubernetes / API-server dashboard rebuilds across seven agent sessions, the `building-dashboards` skill kept exposing footguns. The branch grew into a full overhaul of that skill — new tooling, two new reference docs, a restructured SKILL.md, and a tightened ruleset — alongside the original parameter-passing feature.

The diff: **2,840 insertions / 1,134 deletions across 25 files** in three skills (`building-dashboards`, `query-metrics`, `controlling-costs`).

---

## What changed, by area

### 1. MPL parameter values (the original feature)

Commits: `97e1e32`, `66ca029`.

- **`scripts/metrics-query`** (vendored in both `query-metrics` and `building-dashboards`): new repeatable `-p / --param name=value` flag. Each entry is forwarded under `params.param__<name>` on the JSON body of `POST /v1/query/_mpl`; the script applies the `param__` prefix, strips the leading `$`, and passes the value through verbatim. Dataset extraction now skips leading `param ...;` declarations so a colon inside a declaration doesn't shadow the `dataset:metric` separator.
- **`skills/query-metrics/SKILL.md`**: new "Passing parameter values" subsection documenting the API contract, request-body shape, CLI invocation, and required-vs-optional behavior. Defers MPL-side declaration syntax and per-type literal formatting to `metrics-spec`.
- **`skills/building-dashboards/reference/metrics-mpl.md`**: single pointer to the new subsection in `query-metrics`. No content duplication.
- **`scripts/metrics-info`**: now exposes metric `type` / `temporality` / `unit` metadata, used by the new `unit-for` helper and consumers downstream.

API contract:

```json
{
  "apl": "param $svc: string; param $window: Duration; `otel-metrics`:`http.server.duration` | where `service.name` == $svc | align to $window using avg",
  "startTime": "now-1h",
  "endTime": "now",
  "params": {
    "param__svc": "\"frontend\"",
    "param__window": "5m"
  }
}
```

CLI:

```bash
scripts/metrics-query \
  -p svc='"frontend"' \
  -p window='5m' \
  prod \
  'param $svc: string; param $window: Duration; `otel-metrics`:`http.server.duration` | where `service.name` == $svc | align to $window using avg' \
  now-1h now
```

The new flag is **non-breaking** — when absent, the request body is unchanged from before, and existing four-positional-arg invocations continue to work.

### 2. New `building-dashboards` tooling

Commit: `fc516bc` (with `dashboard-validate` and `resolve-url` env support added in `080f2ce`).

| Script                                          | Purpose                                                                                                                |
| :---------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------- |
| `scripts/chart-add`                             | Append a chart to a dashboard JSON, with consistent panel-id assignment and validation hooks.                          |
| `scripts/dashboard-assemble`                    | Build a complete dashboard from a manifest of charts + layout, replacing ad-hoc hand-assembly of dashboard JSON.       |
| `scripts/layout-pack`                           | Compute a layout grid from chart metadata (size hints, groupings) so authors stop placing panels by hand.              |
| `scripts/dashboard-validate`                    | Validate a dashboard JSON against the API before deploy. Now respects `AXIOM_URL_OVERRIDE` (mirrors `axiom-api`).      |
| `scripts/metrics/mpl-validate-chart`            | Validate a single MPL chart definition against the live spec before it ever reaches the dashboard.                     |
| `scripts/metrics/unit-for`                      | Helper that resolves the correct `unit` / `customUnits` chart fields from metric metadata (incl. `%`-fraction handling). |
| `scripts/metrics/resolve-url`                   | Now honors `AXIOM_URL_OVERRIDE` so a single env var works across `axiom-api`, `dashboard-validate`, and the metrics scripts. |
| `tests/unit-for.sh`                             | Test suite for the unit-for helper, covering OTel fraction → percent conversion and the `%` edge case.                 |

### 3. New reference documents

Commit: `080f2ce`.

- **`reference/grafana-migration.md`** — canonical-spec projection (jq), top-level field mapping, visualization-type table, name mapping (Prom → OTel rename rules), reverse-tag discovery for missing labels, and a migration checklist.
- **`reference/promql-to-mpl.md`** — mechanical translation of PromQL selectors, groupings, `rate`, histograms, ratios, boolean step functions, and reverse-tag discovery. Includes the rule "selector values not in the dataset are aliases — cite the source."

### 4. Skill rules added or tightened

Across `c8b064b`, `24f87c6`, `acdb6c3`, `080f2ce`, `fc516bc`:

- **Compute What's Asked, or Defer With a Blocker.** If a panel can't be computed, replace it with a `Note` documenting the blocker. Never silently substitute a different quantity.
- **Required Chart Unit Configuration matrix.** Per-chart-type unit rules covering the asymmetry (e.g., `customUnits` is effectively `Statistic`-only; `Note` panel `text` / `variant` live at chart top-level, not under `options`).
- **OTel percentages arrive as 0–1 fractions.** Must be `| map * 100` before being rendered with `Percent100`.
- **No inline time ranges in chart queries.** Per-panel time override is UI-only; `overrideDashboardTimeRange` is silently dropped on data charts and rejected on Note. Documents the `$__interval` test pattern.
- **`align` belongs in `compute`**, not applied afterward (already shipped via PR #48 / `4517dfa`; reinforced here).
- **Unit-handling guidance** with the `unit-for` helper (commits `c8b064b`, `24f87c6`).

### 5. SKILL.md restructure

`skills/building-dashboards/SKILL.md` was tightened end-to-end. New top-level sections (some renamed, some new):

```
Philosophy
Entry Points                  ← now includes Grafana entry path
Intake: What to Ask First
Dashboard Blueprint
Required Chart Structure
Chart Unit Configuration      ← new, tied to the unit matrix above
Compute or Defer              ← new, tied to the defer-with-blocker rule
Chart Types
Chart Configuration
APL Patterns
Layout Composition
Dashboard Settings
Setup
Deployment
Sibling Skill Integration
Templates
Common Pitfalls
Reference
```

`skills/query-metrics/SKILL.md` was similarly restructured (sections: Workflow, Choosing a Query Shape, Query Metrics, Discovery, Error Handling, Scripts) and lost ~325 lines of redundant prose.

### 6. Cross-skill sync

Helper scripts that exist in both `query-metrics/scripts/` and `building-dashboards/scripts/metrics/` are kept byte-identical per the rule in `metrics-mpl.md`. This branch synchronizes both copies of:

- `metrics-info` (added type/temporality/unit metadata)
- `metrics-query` (added `-p / --param`)
- `resolve-url` (added `AXIOM_URL_OVERRIDE`)

Also updated: `skills/controlling-costs/reference/dashboard-panels.md`, `skills/controlling-costs/templates/dashboard.json`, and `skills/building-dashboards/templates/org-usage-cost-control.json` (extended to use the new tooling and rules).

---

## Verification

The MPL parameter feature was verified against the live MPL spec (`scripts/metrics-spec axiom ha`) and a live deployment:

| Claim                                             | Evidence                                                                                                                                                      |
| :------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| Key = `param__<name>` with `$` stripped           | Spec §Query Parameters: `$__interval`→`param____interval`, `$ds`→`param__ds`, `$re`→`param__re`, `$str`→`param__str`                                          |
| Value = verbatim MPL literal                      | Live test passing `-p eid='"sensor.heizstrom_power"'` returned series identical to a non-parameterized control with the literal substituted directly          |
| JSON `params` body works                          | End-to-end test against `axiom` deployment returned identical results to the literal control                                                                  |
| Required parameters must be supplied              | Live test omitting a required param returned HTTP 400: `"The following params were declared but not provided: eid"`                                           |
| Type-name capitalization                          | Spec uses lowercase `string` and capitalized `Duration` / `Dataset` / `Regex`; examples follow this convention                                                |

The dashboard-skill changes were verified by running the standard Grafana **Kubernetes / API server** dashboard rebuild against `k8s-metrics-staging` across seven agent sessions (see retrospective below).

### Notes

- The spec's optional-parameter mechanism is `Option<T>` + `ifdef`. Docs describe the observable behavior (optional may be omitted, required is required) and defer syntax to `metrics-spec`.
- `Option<T>` was rejected by the parser on the `axiom` deployment build I tested ("expected param type"), even though the spec doesn't flag it as unimplemented. The docs in this PR don't depend on that feature being live.

---

## Session retrospective — Kubernetes / API server dashboard iterations

The dashboards-skill changes on this branch were exercised by re-deploying the standard Grafana **Kubernetes / API server** dashboard against `k8s-metrics-staging` across seven agent sessions. Each session ended with the skill being tightened based on what broke; v6 was a one-shot success against the post-v5 skill.

| #   | Duration   | User msgs (dashboard / follow-up) | Assistant turns | Tool calls | Tool-call mix                          | Tools/min | Outcome                                        |
| :-- | ---------: | :-------------------------------- | --------------: | ---------: | :------------------------------------- | --------: | :--------------------------------------------- |
| v0a | 3 m 44 s   | 2 / 0                             |              28 |         28 | bash 26, read 2                         |       7.5 | abandoned mid-discovery                         |
| v0b | 1 h 47 m   | 3 / 4                             |              99 |         95 | bash 84, read 5, write 4, edit 2        |       0.9 | success + spawned `axiom-staging` skill         |
| v2  | 36 m 39 s  | 1 / 1                             |              62 |         60 | bash 50, edit 5, read 4, write 1        |       1.6 | success                                         |
| v3  | 13 m 58 s  | 2 / 1                             |              56 |         53 | bash 45, read 5, edit 2, write 1        |       3.8 | success                                         |
| v4  | 31 m 40 s  | 1 / 2 (+1 meta)                   |             111 |        107 | bash 80, edit 11, read 10, write 6      |       3.4 | success                                         |
| v5  | 42 m 30 s  | 2 / 6                             |              92 |         85 | bash 71, read 11, write 2, edit 1       |       2.0 | success (after fixing inline-time bug)          |
| v6  | 6 m 24 s   | 1 / 0                             |              55 |         59 | bash 49, read 5, ls 3, write 1, edit 1  |       9.2 | one-shot success                                |

### What each session contributed back to the skills

- **v0b** — created `~/.agents/skills/axiom-staging/` capturing the staging edge URL override (`us-east-1.edge.staging.axiomtestlabs.co`) so later sessions stop reinventing it. (Generalized later in this PR as `AXIOM_URL_OVERRIDE` in `resolve-url` / `dashboard-validate`.)
- **v2** — `building-dashboards`: noted that OTel percentages arrive as 0–1 fractions and must be `| map * 100` before being rendered with `Percent100` (commits `c8b064b`, `24f87c6`).
- **v3** — `building-dashboards`: rule that `align` must be pulled into `compute`, not applied afterwards (already shipped in PR #48 as `4517dfa`, separate from this PR).
- **v4** — `building-dashboards`: documented that `customUnits` is effectively `Statistic`-only and that `Note` panel `text` / `variant` live at chart top-level, not under `options` (commits `c8b064b`, `24f87c6`).
- **v5** — `building-dashboards`: forbade inline time ranges in chart queries, documented `$__interval` test pattern (commit `acdb6c3`).
- **v6** — no skill change required; one-shot success against the post-v5 skill, validating the rules added in v2/v4/v5.

The Grafana migration guide (`grafana-migration.md`) and PromQL→MPL translation rules (`promql-to-mpl.md`) introduced in `080f2ce`, plus the assembly tooling (`chart-add` / `dashboard-assemble` / `layout-pack` / `mpl-validate-chart`) in `fc516bc`, are the **codified output** of these seven sessions — turning hand-assembly + ad-hoc validation into a repeatable workflow.

### Read of the table

- **v6 is dramatically more efficient** than every prior run: 1 prompt, 6 minutes, 55 turns, 59 tool calls — and the highest tool throughput (9.2 / min). The previous fastest success (v3) needed 56 turns over 14 minutes.
- **v0a's high tools/min is misleading** — it's a short, truncated session that never wrote a dashboard.
- **v0b** is the heaviest absolute (99 turns, 95 tool calls, ~108 minutes) because half of it was building a brand-new skill, not the dashboard.
- **v4 is the chattiest** (111 turns, 107 tool calls) because it iterated heavily on the `building-dashboards` skill while debugging custom-units.
- `bash` dominates everywhere (~80–90% of all tool calls).
- v6 has more tool calls than assistant turns (59 > 55) — some turns batched 2+ tool calls in one message, an efficiency pattern the matured skills now encourage.

**Trend:** real user messages dropped from v5 → v6 (8 → 1), the cleanest signal that the v5 skill changes stuck — v6 needed zero corrective follow-ups.

### Scope note

The original PR scope (`97e1e32`, `66ca029`) was the MPL `params` feature alone, from a separate session on May 7. The seven sessions above drove the dashboard-skill commits (`c8b064b`, `24f87c6`, `acdb6c3`, `080f2ce`, `fc516bc`) that this PR now also carries.
