### PR TITLE
building-dashboards: add dashboard chart patch helper

### DIFF
--- a/skills/building-dashboards/README.md
+++ b/skills/building-dashboards/README.md
@@ -58,6 +58,7 @@ scripts/dashboard-create <deployment> ./dashboard.json
 # List, update, delete
 scripts/dashboard-list <deployment>
 scripts/dashboard-update <deployment> <id> <file>
+scripts/dashboard-chart-patch <deployment> <id> <chart-id> <patch-file> --version <version>
 scripts/dashboard-delete <deployment> <id>
 ```
 
@@ -70,9 +71,28 @@ scripts/dashboard-delete <deployment> <id>
 | `dashboard-list` | List all dashboards |
 | `dashboard-get` | Fetch dashboard JSON |
 | `dashboard-update` | Update existing dashboard |
+| `dashboard-chart-patch` | Patch one chart in an existing dashboard |
 | `dashboard-copy` | Clone a dashboard |
 | `dashboard-delete` | Delete with confirmation |
 | `dashboard-from-template` | Generate from template |
+
+## Chart Patches
+
+Use `dashboard-chart-patch` when only one existing chart needs to change. The patch file is a JSON Merge Patch applied to that chart: include only fields to change, and set a field to `null` to remove it.
+
+```bash
+cat > chart.patch.json <<'JSON'
+{
+  "name": "Error Rate (5m)",
+  "query": { "apl": "['logs'] | summarize errors=countif(status >= 500)" },
+  "config": { "stale": null }
+}
+JSON
+
+scripts/dashboard-chart-patch prod dashboard-uid error-rate chart.patch.json --version 12
+```
+
+Use `--version` for optimistic concurrency. Use `--overwrite` only when last-write-wins is intended. If the patch includes `id`, it must match the chart ID in the command.
 
 ## Templates
 

--- a/skills/building-dashboards/README.md
+++ b/skills/building-dashboards/README.md
@@ -76,24 +76,6 @@ scripts/dashboard-delete <deployment> <id>
 | `dashboard-delete` | Delete with confirmation |
 | `dashboard-from-template` | Generate from template |
 
-## Chart Patches
-
-Use `dashboard-chart-patch` when only one existing chart needs to change. The patch file is a JSON Merge Patch applied to that chart: include only fields to change, and set a field to `null` to remove it.
-
-```bash
-cat > chart.patch.json <<'JSON'
-{
-  "name": "Error Rate (5m)",
-  "query": { "apl": "['logs'] | summarize errors=countif(status >= 500)" },
-  "config": { "stale": null }
-}
-JSON
-
-scripts/dashboard-chart-patch prod dashboard-uid error-rate chart.patch.json --version 12
-```
-
-Use `--version` for optimistic concurrency. Use `--overwrite` only when last-write-wins is intended. If the patch includes `id`, it must match the chart ID in the command.
-
 ## Templates
 
 Pre-built templates in `reference/templates/`:

--- a/skills/building-dashboards/SKILL.md
+++ b/skills/building-dashboards/SKILL.md
@@ -528,6 +528,7 @@ org_id = "your-org-id"
 | `scripts/dashboard-validate <file>` | Validate JSON structure |
 | `scripts/dashboard-create <deploy> <file>` | Create dashboard |
 | `scripts/dashboard-update <deploy> <id> <file>` | Update (needs version) |
+| `scripts/dashboard-chart-patch <deploy> <id> <chart-id> <patch-file> (--version <version> \| --overwrite)` | Patch one chart |
 | `scripts/dashboard-copy <deploy> <id>` | Clone dashboard |
 | `scripts/dashboard-link <deploy> <id>` | Get shareable URL |
 | `scripts/dashboard-delete <deploy> <id>` | Delete (with confirm) |
@@ -539,6 +540,24 @@ org_id = "your-org-id"
 | `scripts/metrics/metrics-query <deploy> <mpl> <start> <end>` | Execute a metrics query |
 
 > **⚠️ Two `axiom-api` scripts exist with different behaviors.** `scripts/axiom-api` rewrites URLs for the dashboard app API (`app.*`). `scripts/metrics/axiom-api` uses raw URLs and supports edge deployment routing. Using the wrong one will produce 404 errors.
+
+### Targeted Chart Updates
+
+Use `scripts/dashboard-chart-patch` when changing one existing chart and the dashboard layout, metadata, and other charts should remain untouched. It calls `PATCH /v2/dashboards/uid/{uid}/charts/{chartId}` with a JSON Merge Patch under the `chart` request field.
+
+Patch files contain only the chart fields to change:
+
+```json
+{
+  "name": "Error Rate (5m)",
+  "query": { "apl": "['logs'] | summarize errors=countif(status >= 500)" },
+  "config": { "stale": null }
+}
+```
+
+`null` removes an existing field. Nested objects merge recursively. If `id` is present in the patch, it must match the `<chart-id>` path argument. The server validates the resulting full dashboard before saving.
+
+Use `--version <version>` for optimistic concurrency after fetching the dashboard with `dashboard-get`. Use `--overwrite` only when last-write-wins behavior is intended. Continue using `dashboard-update` for layout changes, multi-chart edits, dashboard metadata, owner, refresh interval, or time window updates.
 
 ### Workflow
 

--- a/skills/building-dashboards/scripts/dashboard-chart-patch
+++ b/skills/building-dashboards/scripts/dashboard-chart-patch
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# dashboard-chart-patch: Patch one chart in an existing dashboard
+#
+# Usage:
+#   dashboard-chart-patch <deployment> <dashboard-uid> <chart-id> <patch-json-file> (--version <version> | --overwrite) [--message <message>]
+#
+# The patch file must contain a JSON object. It is sent as the `chart` JSON
+# merge patch, so null values remove existing chart fields.
+#
+# Examples:
+#   dashboard-chart-patch prod dash-uid error-rate ./chart.patch.json --version 12
+#   dashboard-chart-patch prod dash-uid error-rate ./chart.patch.json --overwrite --message "Update error chart"
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+    echo "Usage: dashboard-chart-patch <deployment> <dashboard-uid> <chart-id> <patch-json-file> (--version <version> | --overwrite) [--message <message>]" >&2
+}
+
+DEPLOYMENT="${1:-}"
+DASHBOARD_UID="${2:-}"
+CHART_ID="${3:-}"
+PATCH_FILE="${4:-}"
+
+if [[ $# -lt 4 || -z "$DEPLOYMENT" || -z "$DASHBOARD_UID" || -z "$CHART_ID" || -z "$PATCH_FILE" ]]; then
+    usage
+    exit 1
+fi
+
+shift 4
+
+VERSION=""
+OVERWRITE="false"
+MESSAGE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version)
+            if [[ $# -lt 2 || -z "${2:-}" ]]; then
+                echo "Error: --version requires a value" >&2
+                usage
+                exit 1
+            fi
+            VERSION="$2"
+            shift 2
+            ;;
+        --overwrite)
+            OVERWRITE="true"
+            shift
+            ;;
+        --message)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --message requires a value" >&2
+                usage
+                exit 1
+            fi
+            MESSAGE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! -f "$PATCH_FILE" ]]; then
+    echo "Error: File not found: $PATCH_FILE" >&2
+    exit 1
+fi
+
+if [[ "$OVERWRITE" == "true" && -n "$VERSION" ]]; then
+    echo "Error: Use either --version or --overwrite, not both" >&2
+    exit 1
+fi
+
+if [[ "$OVERWRITE" == "false" && -z "$VERSION" ]]; then
+    echo "Error: --version is required unless --overwrite is set" >&2
+    echo "Fetch the current dashboard first: dashboard-get $DEPLOYMENT $DASHBOARD_UID" >&2
+    exit 1
+fi
+
+if [[ -n "$VERSION" && ! "$VERSION" =~ ^[0-9]+$ ]]; then
+    echo "Error: --version must be a numeric dashboard version" >&2
+    exit 1
+fi
+
+if ! jq -e 'type == "object"' "$PATCH_FILE" > /dev/null; then
+    echo "Error: chart patch must be a JSON object" >&2
+    exit 1
+fi
+
+PATCH_ID=$(jq -r 'if has("id") then .id else empty end' "$PATCH_FILE")
+if [[ -n "$PATCH_ID" && "$PATCH_ID" != "$CHART_ID" ]]; then
+    echo "Error: chart patch id must match chart id '$CHART_ID'" >&2
+    exit 1
+fi
+
+CHART_PATCH=$(jq -c '.' "$PATCH_FILE")
+
+BODY=$(jq -n \
+    --argjson chart "$CHART_PATCH" \
+    --arg message "$MESSAGE" \
+    --argjson overwrite "$OVERWRITE" \
+    '{chart: $chart}
+     + (if $overwrite then {overwrite: true} else {} end)
+     + (if $message != "" then {message: $message} else {} end)')
+
+if [[ -n "$VERSION" ]]; then
+    BODY=$(echo "$BODY" | jq --argjson version "$VERSION" '. + {version: $version}')
+fi
+
+RESPONSE=$("$SCRIPT_DIR/axiom-api" "$DEPLOYMENT" PATCH "/dashboards/uid/$DASHBOARD_UID/charts/$CHART_ID" "$BODY")
+
+echo "$RESPONSE" | jq .

--- a/skills/building-dashboards/tests/test-script-output.sh
+++ b/skills/building-dashboards/tests/test-script-output.sh
@@ -26,10 +26,11 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 cp "$SCRIPTS_DIR/dashboard-create" "$TMPDIR/"
 cp "$SCRIPTS_DIR/dashboard-update" "$TMPDIR/"
+cp "$SCRIPTS_DIR/dashboard-chart-patch" "$TMPDIR/"
 cp "$SCRIPTS_DIR/dashboard-validate" "$TMPDIR/"
 cp "$SCRIPTS_DIR/dashboard-normalize.jq" "$TMPDIR/"
 
-chmod +x "$TMPDIR/dashboard-create" "$TMPDIR/dashboard-update" "$TMPDIR/dashboard-validate"
+chmod +x "$TMPDIR/dashboard-create" "$TMPDIR/dashboard-update" "$TMPDIR/dashboard-chart-patch" "$TMPDIR/dashboard-validate"
 
 cat > "$TMPDIR/input.json" <<'JSON'
 {
@@ -57,11 +58,20 @@ cat > "$TMPDIR/input.json" <<'JSON'
 }
 JSON
 
+cat > "$TMPDIR/chart.patch.json" <<'JSON'
+{
+  "name": "Error Rate (5m)",
+  "query": { "apl": "['logs'] | summarize errors=countif(status >= 500)" },
+  "config": { "stale": null }
+}
+JSON
+
 cat > "$TMPDIR/axiom-api" <<'BASH'
 #!/usr/bin/env bash
 set -euo pipefail
 METHOD="${2:-}"
 PATH_="${3:-}"
+BODY="${4:-}"
 
 case "$METHOD:$PATH_" in
   "POST:/dashboards")
@@ -69,6 +79,18 @@ case "$METHOD:$PATH_" in
     ;;
   "PUT:/dashboards/uid/dashboard-root-id")
     echo '{"status":"updated","dashboard":{"uid":"dashboard-root-id","id":"dashboard-root-id","version":2,"dashboard":{"name":"Test Dashboard","updated":true},"createdAt":"2026-02-01T10:00:00Z","updatedAt":"2026-02-02T11:00:00Z","createdBy":"alice@example.com","updatedBy":"bob@example.com"}}'
+    ;;
+  "PATCH:/dashboards/uid/dashboard-root-id/charts/error-rate")
+    echo "$BODY" | jq -e '
+      .chart.name == "Error Rate (5m)" and
+      .chart.query.apl == "['\''logs'\''] | summarize errors=countif(status >= 500)" and
+      (.chart.config | has("stale")) and
+      .chart.config.stale == null and
+      .version == 7 and
+      .message == "Tune error chart" and
+      (.overwrite | not)
+    ' > /dev/null
+    echo '{"status":"updated","dashboard":{"uid":"dashboard-root-id","id":"dashboard-root-id","version":8,"dashboard":{"name":"Test Dashboard","chartPatched":true},"createdAt":"2026-02-01T10:00:00Z","updatedAt":"2026-02-02T12:00:00Z","createdBy":"alice@example.com","updatedBy":"bob@example.com"}}'
     ;;
   *)
     echo "Unexpected call: $METHOD $PATH_" >&2
@@ -94,6 +116,13 @@ if echo "$update_out" | jq -e '.dashboard.uid == "dashboard-root-id" and .dashbo
     ok "dashboard-update outputs valid JSON only"
 else
     fail "dashboard-update outputs valid JSON only" "got: $update_out"
+fi
+
+patch_out=$("$TMPDIR/dashboard-chart-patch" prod dashboard-root-id error-rate "$TMPDIR/chart.patch.json" --version 7 --message "Tune error chart")
+if echo "$patch_out" | jq -e '.dashboard.uid == "dashboard-root-id" and .dashboard.dashboard.chartPatched == true' > /dev/null 2>&1; then
+    ok "dashboard-chart-patch outputs valid JSON only"
+else
+    fail "dashboard-chart-patch outputs valid JSON only" "got: $patch_out"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- Add `dashboard-chart-patch` for `PATCH /v2/dashboards/uid/{uid}/charts/{chartId}`
- Document targeted chart updates versus full dashboard updates
- Cover the helper in script stdout contract tests

## Validation
- `skills/building-dashboards/tests/test-script-output.sh`
- `skills/building-dashboards/tests/test-normalize.sh`
- `skills/building-dashboards/tests/test-templates.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new deployment script that issues a chart-level PATCH request with optional overwrite/version concurrency controls; scope is limited to tooling/docs with a small, well-tested surface area.
> 
> **Overview**
> Adds `scripts/dashboard-chart-patch`, a new helper to **patch a single chart** in an existing dashboard via `PATCH /v2/dashboards/uid/{uid}/charts/{chartId}` using a JSON Merge Patch payload, with support for optimistic concurrency (`--version`) or explicit last-write-wins (`--overwrite`) and an optional audit `--message`.
> 
> Updates the skill docs (`README.md`, `SKILL.md`) to describe when to use targeted chart patches vs full `dashboard-update`, and extends `test-script-output.sh` to assert the new script’s stdout remains machine-readable and that it sends the expected request body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba4432b2ffb6e167ffc7ae8ef6de8a0ae0ad7a5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->