### PR TITLE
Add User-Agent header to identify skill-driven agent traffic

### DIFF
--- a/skills/building-dashboards/scripts/axiom-api
+++ b/skills/building-dashboards/scripts/axiom-api
@@ -80,6 +80,7 @@ CURL_ARGS=(
     -H "X-Axiom-Org-Id: $ORG_ID"
     -H "Content-Type: application/json"
     -H "Accept: application/json"
+    -H "User-Agent: axiom-skills/1.0 (agent)"
 )
 
 if [[ -n "$BODY" ]]; then

--- a/skills/building-dashboards/scripts/metrics/axiom-api
+++ b/skills/building-dashboards/scripts/metrics/axiom-api
@@ -60,6 +60,7 @@ CURL_ARGS=(
     -H "X-Axiom-Org-Id: $ORG_ID"
     -H "Content-Type: application/json"
     -H "Accept: ${AXIOM_ACCEPT:-application/json}"
+    -H "User-Agent: axiom-skills/1.0 (agent)"
 )
 
 if [[ -n "$BODY" ]]; then

--- a/skills/query-metrics/scripts/axiom-api
+++ b/skills/query-metrics/scripts/axiom-api
@@ -57,6 +57,7 @@ CURL_ARGS=(
     -H "X-Axiom-Org-Id: $ORG_ID"
     -H "Content-Type: application/json"
     -H "Accept: ${AXIOM_ACCEPT:-application/json}"
+    -H "User-Agent: axiom-skills/1.0 (agent)"
 )
 
 if [[ -n "$BODY" ]]; then

--- a/skills/sre/scripts/axiom-query
+++ b/skills/sre/scripts/axiom-query
@@ -154,6 +154,7 @@ HTTP_CODE=$(curl -sS -o "$RESP_BODY" -D "$RESP_HEADERS" -w "%{http_code}" \
   -H "Authorization: Bearer $AXIOM_TOKEN" \
   -H "X-Axiom-Org-Id: $AXIOM_ORG_ID" \
   -H "Content-Type: application/json" \
+  -H "User-Agent: axiom-skills/1.0 (agent)" \
   -d "$PAYLOAD")
 
 if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then

--- a/skills/sre/scripts/curl-auth
+++ b/skills/sre/scripts/curl-auth
@@ -136,6 +136,7 @@ case "$TOOL" in
             -H "Authorization: Bearer $AXIOM_TOKEN" \
             -H "X-Axiom-Org-Id: $AXIOM_ORG_ID" \
             -H "Content-Type: application/json" \
+            -H "User-Agent: axiom-skills/1.0 (agent)" \
             "$URL" "$@"
         ;;
     


### PR DESCRIPTION
All Axiom API calls from these skills now send `axiom-skills/1.0 (agent)` as the User-Agent, making them identifiable in axiom-traces-prod alongside MCP traffic (`axiom-mcp-server (hosted)`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds an extra request header to a handful of shell scripts, with minimal chance of affecting request semantics unless the upstream rejects/varies behavior on `User-Agent`.
> 
> **Overview**
> All Axiom API calls made by these skills now include `User-Agent: axiom-skills/1.0 (agent)` in their `curl` requests.
> 
> This updates the dashboard/app `axiom-api`, the data/metrics `axiom-api` variants, `axiom-query`, and the `curl-auth` Axiom mode so skill-driven traffic is consistently identifiable in downstream traces/logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90d5c9d91f87f41aae9ced0fafcaa61461e940ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->