### PR TITLE
Document filter bar + MPL ifdef pattern

### DIFF
--- a/skills/building-dashboards/SKILL.md
+++ b/skills/building-dashboards/SKILL.md
@@ -322,13 +322,22 @@ SmartFilter is a **chart type** that creates dropdown/search filters. Requires:
 - `selectType: "list"` — Static dropdown with predefined options
 - `type: "search"` — Free-text input
 
-**Panel query pattern:**
+**APL panel query pattern:**
 ```apl
 declare query_parameters (country_filter:string = "");
 ['logs'] | where isempty(country_filter) or ['geo.country'] == country_filter
 ```
 
-See `reference/smartfilter.md` for full JSON structure and cascading filter examples.
+**MPL (metrics) panel query pattern — use `ifdef`, not `declare query_parameters`:**
+```mpl
+`dataset`:`metric`
+| ifdef($service_filter) { where `service.name` == $service_filter }
+| align to $__interval using avg
+```
+
+For MPL, the default "All" option in the filter bar **must** have `"unset": true` so the variable is treated as optional. The dashboard runtime auto-injects the `param $<id>: Option<string>;` declaration — do not add it manually. When the filter is unset the `ifdef` block is skipped entirely.
+
+See `reference/smartfilter.md` for full JSON structure, `unset` option details, and cascading filter examples.
 
 ### Monitor List
 **When:** Display monitor status on operational dashboards.

--- a/skills/building-dashboards/reference/metrics-mpl.md
+++ b/skills/building-dashboards/reference/metrics-mpl.md
@@ -49,6 +49,44 @@ When generating metrics chart JSON:
 
 > **Note:** `find-metrics <value>` searches tag values, not metric names. Use `metrics-info <deploy> <dataset> metrics` to list metric names.
 
+## Filter Bar / SmartFilter Integration
+
+Metrics charts support optional filter bar variables via the `ifdef` operator. When the filter bar is unset (the "All" / no-filter default is active) the `ifdef` block is skipped and all series are returned. When a value is selected, the filter is applied.
+
+### Chart query
+
+Use `ifdef` in the MPL pipeline. **Do not** add `param` declarations to the chart query string — the dashboard runtime injects them automatically from the filter bar metadata.
+
+```mpl
+`otel-metrics`:`http.server.duration`
+| ifdef($service_filter) { where `service.name` == $service_filter }
+| align to $__interval using avg
+| group by `service.name` using avg
+```
+
+### Filter bar JSON
+
+The "All" default option **must** include `"unset": true`. Without it the variable is sent as an empty string (a required `string` param), which causes the MPL engine to error because `ifdef` expects `Option<string>`.
+
+```json
+{
+  "id": "service_filter",
+  "name": "Service",
+  "type": "select",
+  "selectType": "apl",
+  "active": true,
+  "apl": {
+    "apl": "['logs'] | distinct ['service.name'] | project key=['service.name'], value=['service.name'] | sort by key asc",
+    "queryOptions": {"quickRange": "1h"}
+  },
+  "options": [
+    {"key": "All", "value": "", "default": true, "unset": true}
+  ]
+}
+```
+
+See `reference/smartfilter.md` for the full SmartFilter JSON structure.
+
 ## Metrics Discovery & Query Scripts
 
 | Script | Usage |

--- a/skills/building-dashboards/reference/smartfilter.md
+++ b/skills/building-dashboards/reference/smartfilter.md
@@ -77,9 +77,9 @@ Free-text input instead of dropdown:
 }
 ```
 
-## Panel Query Integration
+## Panel Query Integration (APL)
 
-Panel queries must declare parameters and handle empty (All) case:
+APL panel queries declare parameters and handle the empty ("All") case:
 
 ```apl
 declare query_parameters (country_filter:string = "");
@@ -87,6 +87,40 @@ declare query_parameters (country_filter:string = "");
 | where isempty(country_filter) or ['geo.country'] == country_filter
 | summarize count() by bin_auto(_time)
 ```
+
+## Panel Query Integration (MPL / Metrics)
+
+Metrics charts use `ifdef` instead of `declare query_parameters`. The dashboard runtime automatically injects the `param $<id>: Option<string>;` declaration when the filter has an unset-default option — no manual declaration is needed in the chart query.
+
+```mpl
+`my-dataset`:`http.server.duration`
+| ifdef($service_filter) { where `service.name` == $service_filter }
+| align to $__interval using avg
+| group by `service.name` using avg
+```
+
+For this to work the filter bar option that means "no filter" must have `"unset": true` instead of just `"default": true`:
+
+```json
+{
+  "id": "service_filter",
+  "name": "Service",
+  "type": "select",
+  "selectType": "apl",
+  "active": true,
+  "apl": {
+    "apl": "['my-dataset'] | distinct ['service.name'] | project key=['service.name'], value=['service.name'] | sort by key asc",
+    "queryOptions": {"quickRange": "1h"}
+  },
+  "options": [
+    {"key": "All", "value": "", "default": true, "unset": true}
+  ]
+}
+```
+
+The `unset: true` field signals that when this option is selected the variable is passed as an optional type. The `ifdef` block is then skipped entirely — the query returns all series instead of erroring on a missing required parameter.
+
+**Without `unset: true` on the default option** the variable is sent as an empty string, which is a required `string` param — the MPL engine rejects it because `ifdef` expects `Option<string>`. Always set `unset: true` on the "All" / no-filter default when writing MPL queries with `ifdef`.
 
 ## Filter Query for Dynamic Dropdowns
 


### PR DESCRIPTION
When a filter bar variable is unset, MPL queries need ifdef to skip the filter rather than erroring on a missing required param.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to dashboard-building skills; no runtime or API behavior changes.
> 
> **Overview**
> Documents how **metrics/MPL dashboards** wire the filter bar to panel queries, contrasting with the existing APL `declare query_parameters` pattern.
> 
> **`SKILL.md`** adds chart-type guidance (heatmap histogram, scatter, SmartFilter, Monitor List) and spells out SmartFilter for MPL: use `ifdef($filter)` in the pipeline, require `"unset": true` on the default **All** option so the runtime treats the variable as `Option<string>`, and rely on auto-injected `param` declarations instead of `declare query_parameters`.
> 
> **`reference/smartfilter.md`** splits panel integration into **APL** vs **MPL / Metrics**, with MPL examples and explicit failure mode when `unset` is missing (empty string vs optional param).
> 
> **`reference/metrics-mpl.md`** expands the authoring checklist, adds a **Filter Bar / SmartFilter Integration** section (same `ifdef` + `unset` contract), and a metrics discovery script table. *Note for reviewers:* the diff leaves a **duplicate numbered checklist** after the new script table (steps 1–7 repeat older content with `mpl-validate-chart`); likely accidental merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e391302b5354fc0212330b4c04423cdac689942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->