### PR TITLE
Add Grok plugin manifest

### DIFF
--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "axiom",
+  "version": "1.0.0",
+  "description": "Agent skills for the Axiom observability platform. Run hypothesis-driven SRE investigations, query logs and metrics with APL, build dashboards, manage monitors and alerts, translate Splunk SPL queries, and analyze and optimize costs.",
+  "author": {
+    "name": "Axiom",
+    "url": "https://axiom.co"
+  },
+  "homepage": "https://github.com/axiomhq/skills",
+  "repository": "https://github.com/axiomhq/skills",
+  "license": "MIT",
+  "keywords": ["axiom", "observability", "apl", "sre", "monitoring"]
+}


### PR DESCRIPTION
Grok Build derives the installed plugin name from `.grok-plugin/plugin.json` in the source repo, not from the marketplace catalog entry.

Without this manifest, `grok plugin install axiom` installs as `skills-<hash>` instead of `axiom`.

Adds a manifest matching the marketplace catalog metadata so installs register correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only metadata with no runtime, auth, or application logic changes.
> 
> **Overview**
> Adds **`.grok-plugin/plugin.json`** so Grok Build can read the plugin identity from the repo instead of falling back to a generated `skills-<hash>` name.
> 
> The manifest sets **`name`** to `axiom` and includes version, description, author, repo links, license, and keywords aligned with the marketplace catalog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1767e5d1bc345ebe62458825bcbade1dc158d84f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->