### PR TITLE
Add Axiom MCP Server config for Grok marketplace plugin

### DIFF
--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,13 +1,14 @@
 {
   "name": "axiom",
   "version": "1.0.0",
-  "description": "Agent skills for the Axiom observability platform. Run hypothesis-driven SRE investigations, query logs and metrics with APL, build dashboards, manage monitors and alerts, translate Splunk SPL queries, and analyze and optimize costs.",
+  "description": "Official Axiom plugin for Grok (MCP Server + Skills). Query logs and metrics with APL, run SRE investigations, build dashboards, manage monitors and alerts, translate Splunk SPL, and optimize costs.",
   "author": {
     "name": "Axiom",
     "url": "https://axiom.co"
   },
-  "homepage": "https://github.com/axiomhq/skills",
+  "homepage": "https://axiom.co/docs/console/intelligence/mcp-server",
   "repository": "https://github.com/axiomhq/skills",
   "license": "MIT",
-  "keywords": ["axiom", "observability", "apl", "sre", "monitoring"]
+  "keywords": ["axiom", "observability", "apl", "mcp"],
+  "skills": "./skills/"
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "axiom": {
+      "type": "http",
+      "url": "https://mcp.axiom.co/mcp",
+      "note": "Official Axiom hosted MCP server. Uses OAuth — on first connection the agent is prompted to authorize via browser. Tools: queryApl, listDatasets, listDashboards, createMonitor, and more. Server source: https://github.com/axiomhq/mcp"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Agent skills for working with [Axiom](https://axiom.co). Skills are folders of i
 - **curl** - HTTP client (usually pre-installed)
 - **bc** - Calculator, needed by controlling-costs (`brew install bc` or `apt install bc`)
 
+## MCP Server
+
+`.mcp.json` configures the hosted [Axiom MCP Server](https://github.com/axiomhq/mcp) at `https://mcp.axiom.co/mcp` for agent clients that install plugins from a manifest. See the [MCP setup docs](https://axiom.co/docs/console/intelligence/mcp-server).
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Bundle the hosted MCP endpoint (https://mcp.axiom.co/mcp) alongside existing skills so the axiom marketplace entry ships both components. Update the Grok plugin manifest; document MCP in README without platform-specific install instructions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and manifest/config only; no application code or security-sensitive logic changes.
> 
> **Overview**
> The Grok marketplace **axiom** plugin now ships **MCP + skills** together: a new **`.mcp.json`** points agent clients at the hosted HTTP MCP endpoint (`https://mcp.axiom.co/mcp`) with OAuth and a short note on available tools.
> 
> **`.grok-plugin/plugin.json`** is updated to describe the official Grok plugin (MCP + skills), set **homepage** to Axiom’s MCP docs, add **`skills`: `./skills/`**, and refresh **keywords** (adds `mcp`, drops `sre`/`monitoring`).
> 
> **README** adds an **MCP Server** section that explains `.mcp.json` and links to the MCP setup docs—no new platform-specific install steps beyond existing skills install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 188b43a7dac625cdac42cddb7ea71730077e0526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->