### PR TITLE
skills/building-dashboards: newline-format chart-add pipelines

### DIFF
--- a/skills/building-dashboards/scripts/chart-add
+++ b/skills/building-dashboards/scripts/chart-add
@@ -195,13 +195,21 @@ unit_fields_other() {
     fi
 }
 
+# Newline before each pipeline `|` so stored queries read one stage per line.
+# Quote-aware: the alternation consumes whole '...'/"..." literals first, so a
+# `|` inside a string is left untouched.
+format_pipeline() {
+    jq -rn --arg apl "$1" \
+        '$apl | gsub("(?<s>\"[^\"]*\"|'\''[^'\'']*'\'')|(?<p> \\| )"; if .s then .s else "\n| " end)'
+}
+
 # Build the query object. Both APL and MPL land in `query.apl` (shared API
 # field); MPL also gets `query.metricsDataset`.
 build_query() {
     if [[ -n "$MPL" ]]; then
-        jq -n --arg apl "$MPL" --arg ds "$DATASET" '{apl: $apl, metricsDataset: $ds}'
+        jq -n --arg apl "$(format_pipeline "$MPL")" --arg ds "$DATASET" '{apl: $apl, metricsDataset: $ds}'
     else
-        jq -n --arg apl "$APL" '{apl: $apl}'
+        jq -n --arg apl "$(format_pipeline "$APL")" '{apl: $apl}'
     fi
 }
 

--- a/skills/building-dashboards/scripts/chart-add
+++ b/skills/building-dashboards/scripts/chart-add
@@ -196,9 +196,16 @@ unit_fields_other() {
 }
 
 # Newline before each pipeline `|` so stored queries read one stage per line.
-# Quote-aware: the alternation consumes whole '...'/"..." literals first, so a
-# `|` inside a string is left untouched.
+# The split only tracks plain '...'/"..." literals, so it bails out and stores
+# the query untouched when it holds a construct whose string boundaries it
+# cannot follow: a backslash escape, an @-verbatim literal (where `\` is not an
+# escape), or a // comment. Formatting is cosmetic, silently rewriting a query
+# is not, so anything ambiguous stays on one line.
 format_pipeline() {
+    if [[ "$1" == *\\* || "$1" == *"@'"* || "$1" == *'@"'* || "$1" == *"//"* ]]; then
+        printf '%s' "$1"
+        return
+    fi
     jq -rn --arg apl "$1" \
         '$apl | gsub("(?<s>\"[^\"]*\"|'\''[^'\'']*'\'')|(?<p> \\| )"; if .s then .s else "\n| " end)'
 }

--- a/skills/building-dashboards/tests/test-script-output.sh
+++ b/skills/building-dashboards/tests/test-script-output.sh
@@ -125,6 +125,22 @@ else
     fail "dashboard-chart-patch outputs valid JSON only" "got: $patch_out"
 fi
 
+apl_fmt=$("$SCRIPTS_DIR/chart-add" --type Statistic --id t --name T \
+    --apl "['logs'] | where a=='x' | summarize c=count()" | jq -r '.query.apl')
+if [[ "$(printf '%s' "$apl_fmt" | grep -c '^| ')" == "2" && "$apl_fmt" != *" | "* ]]; then
+    ok "chart-add breaks each pipeline stage onto its own line"
+else
+    fail "chart-add breaks each pipeline stage onto its own line" "got: $apl_fmt"
+fi
+
+apl_str=$("$SCRIPTS_DIR/chart-add" --type Statistic --id t --name T \
+    --apl "['logs'] | where msg=='a | b'" | jq -r '.query.apl')
+if [[ "$apl_str" == *"msg=='a | b'"* ]]; then
+    ok "chart-add leaves a pipe inside a string literal untouched"
+else
+    fail "chart-add leaves a pipe inside a string literal untouched" "got: $apl_str"
+fi
+
 echo ""
 echo "======================"
 echo "Passed: $passed | Failed: $failed"

--- a/skills/building-dashboards/tests/test-script-output.sh
+++ b/skills/building-dashboards/tests/test-script-output.sh
@@ -141,6 +141,23 @@ else
     fail "chart-add leaves a pipe inside a string literal untouched" "got: $apl_str"
 fi
 
+# Constructs whose string boundaries the split cannot follow must round-trip
+# byte-for-byte rather than risk a newline landing inside a literal.
+check_verbatim() {
+    local label="$1" input="$2" got
+    got=$("$SCRIPTS_DIR/chart-add" --type Statistic --id t --name T --apl "$input" | jq -r '.query.apl')
+    if [[ "$got" == "$input" ]]; then
+        ok "chart-add stores $label untouched"
+    else
+        fail "chart-add stores $label untouched" "got: $got"
+    fi
+}
+
+check_verbatim "a backslash-escaped quote" '["logs"] | where msg == "a \" b | c" | project msg'
+check_verbatim "an @-verbatim literal" '["logs"] | where p == @"c:\x | y" | project p'
+check_verbatim "a // comment" '["logs"] // note | here
+| count'
+
 echo ""
 echo "======================"
 echo "Passed: $passed | Failed: $failed"


### PR DESCRIPTION
`chart-add` stored the `--apl`/`--mpl` string verbatim, so single-line queries produced single-line, hard-to-read dashboard panels. This breaks before each pipeline `|` on store, one stage per line.

The split is quote-aware: the regex consumes whole `'...'`/`"..."` literals first, so a `|` inside a string is left intact. Added two assertions in `test-script-output.sh` covering both (stage-per-line, and a string-internal pipe untouched).

## Testing

`tests/test-script-output.sh` passes (5/5). New cases: a 3-stage query breaks into 3 lines with no residual ` | `, and `where msg=='a | b'` keeps its literal pipe. The other suites (`test-normalize`, `test-templates`) are unaffected and still green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic query formatting on chart JSON emission with explicit no-op paths for ambiguous APL; no API or deployment behavior changes beyond stored query text layout.
> 
> **Overview**
> `chart-add` now runs `--apl` / `--mpl` through **`format_pipeline`** before writing `query.apl`, inserting a newline before each pipeline `|` so multi-stage queries store one stage per line instead of a single hard-to-read line.
> 
> The formatter is quote-aware (pipes inside `'...'` / `"..."` stay put) and **skips rewriting** when the query may contain constructs it cannot parse safely—backslash escapes, `@` verbatim strings, or `//` comments—so those inputs round-trip unchanged.
> 
> `test-script-output.sh` adds coverage for stage-per-line formatting, literal pipes in strings, and the verbatim round-trip cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d65a2ffaf0eecea71f04740234b454455d5dde62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->